### PR TITLE
RED-52: remove dynamic edge config

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,6 @@ import {
   sleep,
   cleanBadNodes,
   initSyncTime,
-  updateEdgeNodeConfig,
 } from './utils'
 import { router as logRoute } from './routes/log'
 import { router as authenticate } from './routes/authenticate'
@@ -204,12 +203,10 @@ setupArchiverDiscovery({
     debug_info.txRecordingStartTime = config.recordTxStatus ? Date.now() : 0
     setConsensorNode()
     initSyncTime()
-    updateEdgeNodeConfig()
     setInterval(updateNodeList, config.nodelistRefreshInterval)
     setInterval(saveTxStatus, 5000)
     setInterval(checkArchiverHealth, 60000)
     setInterval(cleanBadNodes, 60000)
-    setInterval(updateEdgeNodeConfig, 60000 * 5)
     extendedServer.listen(port, function () {
       console.log(`JSON RPC Server listening on port ${port} and chainId is ${chainId}.`)
       setupDatabase()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,8 +43,6 @@ export const node = {
   port: 9001,
 }
 
-let rotationEdgeToAvoid = 0
-
 const badNodesMap: Map<string, number> = new Map()
 
 const verbose = config.verbose
@@ -151,20 +149,6 @@ export async function updateNodeList(tryInfinate = false): Promise<void> {
 
 export function removeFromNodeList(ip: string, port: string): void {
   nodeList = nodeList.filter((node) => node.ip !== ip || node.port !== Number(port))
-}
-
-export async function updateEdgeNodeConfig(): Promise<void> {
-  console.log(`Updating rotationEdgeToAvoid configuration`)
-
-  const res = await requestWithRetry(RequestMethod.Get, `/netconfig`)
-
-  if (res.data && res.data.config) {
-    const newRotationEdgeToAvoid = res.data.config.p2p.rotationEdgeToAvoid
-    rotationEdgeToAvoid = newRotationEdgeToAvoid
-    console.log(`Setting rotationEdgeToAvoid to ${newRotationEdgeToAvoid}`)
-  } else if (res.data && res.data.error) {
-    console.log(`Error getting rotationEdgeToAvoid configuration: ${res.data.error}`)
-  }
 }
 
 export async function checkArchiverHealth(): Promise<void> {


### PR DESCRIPTION
https://linear.app/shm/issue/RED-52/remove-dynamic-edge-rotation-config-from-rpc

Summary:  We no longer need avoid edge configuration in rpc, removing