### PR TITLE
GREEN-30 delete dashboard endpoint in server.ts that touch the filesy…

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -90,9 +90,6 @@ if (config.dashboard.enabled && config.dashboard.dist_path) {
   app.set('views', clientDirectory)
   app.use('/static', express.static(staticDirectory))
   // app.set('views', clientDirectory);
-  app.get('/dashboard', function (req, res) {
-    return res.sendFile(path.join(clientDirectory, 'index.html'))
-  })
 }
 
 app.get('/api/subscribe', authorize, (req: Request, res: Response) => {


### PR DESCRIPTION
GREEN-30
Delete the dashboard endpoint in server.ts that touches the filesystem.
Is the repository named "Rpc Gateway Frontend" still in use? 
If not, can we delete the code related to dashboard.enable and dashboard.dist_path?