### PR TITLE
RED-93: Set request retries dynamically 

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ import {
   sleep,
   cleanBadNodes,
   initSyncTime,
-  updateEdgeNodeConfig,
+  updateRequestRetries,
 } from './utils'
 import { router as logRoute } from './routes/log'
 import { router as authenticate } from './routes/authenticate'
@@ -208,12 +208,12 @@ setupArchiverDiscovery({
     debug_info.txRecordingStartTime = config.recordTxStatus ? Date.now() : 0
     setConsensorNode()
     initSyncTime()
-    updateEdgeNodeConfig()
+    updateRequestRetries()
     setInterval(updateNodeList, config.nodelistRefreshInterval)
     setInterval(saveTxStatus, 5000)
     setInterval(checkArchiverHealth, 60000)
     setInterval(cleanBadNodes, 60000)
-    setInterval(updateEdgeNodeConfig, 60000 * 5)
+    setInterval(updateRequestRetries, 60000 * 5)
     extendedServer.listen(port, function () {
       console.log(`JSON RPC Server listening on port ${port} and chainId is ${chainId}.`)
       setupDatabase()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,8 +44,6 @@ export const node = {
   port: 9001,
 }
 
-let rotationEdgeToAvoid = 0
-
 const badNodesMap: Map<string, number> = new Map()
 
 const verbose = config.verbose
@@ -151,18 +149,20 @@ export async function updateNodeList(tryInfinate = false): Promise<void> {
 }
 
 export function removeFromNodeList(ip: string, port: string): void {
+  console.log(`Removing node ${ip}:${port} from nodeList`)
   nodeList = nodeList.filter((node) => node.ip !== ip || node.port !== Number(port))
+  console.log(nodeList.map((node) => `${node.port}`))
 }
 
-export async function updateEdgeNodeConfig(): Promise<void> {
-  console.log(`Updating rotationEdgeToAvoid configuration`)
+export async function updateRequestRetries(): Promise<void> {
+  console.log(`Updating defaultRequestRetry configuration`)
 
   const res = await requestWithRetry(RequestMethod.Get, `/netconfig`)
 
   if (res.data && res.data.config) {
     const newRotationEdgeToAvoid = res.data.config.p2p.rotationEdgeToAvoid
-    rotationEdgeToAvoid = newRotationEdgeToAvoid
-    console.log(`Setting rotationEdgeToAvoid to ${newRotationEdgeToAvoid}`)
+    config.defaultRequestRetry = newRotationEdgeToAvoid * 2
+    console.log(`Setting request retries to ${config.defaultRequestRetry}`)
   } else if (res.data && res.data.error) {
     console.log(`Error getting rotationEdgeToAvoid configuration: ${res.data.error}`)
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -161,7 +161,9 @@ export async function updateRequestRetries(): Promise<void> {
 
   if (res.data && res.data.config) {
     const newRotationEdgeToAvoid = res.data.config.p2p.rotationEdgeToAvoid
-    config.defaultRequestRetry = newRotationEdgeToAvoid * 2
+    if (newRotationEdgeToAvoid > config.defaultRequestRetry) {
+        config.defaultRequestRetry = newRotationEdgeToAvoid * 2
+    }
     console.log(`Setting request retries to ${config.defaultRequestRetry}`)
   } else if (res.data && res.data.error) {
     console.log(`Error getting rotationEdgeToAvoid configuration: ${res.data.error}`)


### PR DESCRIPTION
https://linear.app/shm/issue/RED-93/dynamically-set-rpc-retry-config-to-be-rotationedgetoavoid-2

Summary:  Set RPC request retries by fetching rotationEdgeToAvoid config from a node and doubling it.  Repurposing old code that is meant to be removed in RED-52 