### PR TITLE
RED-94: Default to use random consensor selection.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -101,6 +101,7 @@ type Config = {
   }
 
   enableBlockCache: boolean
+  useRoundRobinConsensorSelection: boolean
 }
 
 export type ServicePointTypes = 'aalg-warmup'
@@ -196,4 +197,5 @@ export const CONFIG: Config = {
     ['aalg-warmup']: 20,
   },
   enableBlockCache: false,
+  useRoundRobinConsensorSelection: true,
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -401,7 +401,9 @@ function rotateConsensorNode(): void {
   let success = false
   while (count < maxRetry && !success) {
     count++
-    const consensor: Node | null = getNextConsensorNode() //getRandomConsensorNode()
+    const consensor: Node | null = config.useRoundRobinConsensorSelection
+      ? getNextConsensorNode()
+      : getRandomConsensorNode()
     const ipPort = `${consensor?.ip}:${consensor?.port}`
     if (consensor && !badNodesMap.has(ipPort)) {
       let nodeIp = consensor.ip


### PR DESCRIPTION
https://linear.app/shm/issue/RED-94/use-random-node-selection-in-rpc-instead-of-round-robin

Summary: Use random consensor selection by default.  add config to toggle between random and round robin