### PR TITLE
BLUE-70: Fix issue in `eth_getBalance` and `eth_getTransactionCount`

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1063,9 +1063,8 @@ export const methods = {
           countSuccessResponse(api_name, 'success', 'validator')
         } else {
           if (verbose) console.log('Shardeum balance', typeof account.balance, account.balance)
-          const SHD = intStringToHex(account.balance)
-          if (verbose) console.log('SHD', typeof SHD, SHD)
-          balance = intStringToHex(account.balance)
+          const balance = intStringToHex(account.balance)
+          if (verbose) console.log('SHD', typeof balance, balance)
           logEventEmitter.emit('fn_end', ticket, { nodeUrl, success: true }, performance.now())
           callback(null, balance)
           countSuccessResponse(api_name, 'success', 'validator')
@@ -3632,7 +3631,7 @@ export const methods = {
       countFailedResponse(api_name, 'Invalid address')
       return
     }
-    
+
     if (!isValidAddress(callObj.from)) {
       if (verbose) console.log('Invalid params: `from` is not valid address', callObj.from)
       callback({ code: -32000, message: 'Invalid params: `from` is not valid address' }, null)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -317,6 +317,11 @@ export async function requestWithRetry(
     if (retry <= maxRetry) {
       if (verbose) console.log(`(Attempt ${retry}) Node is unable to respond. Trying a new node.`)
       await waitRandomSecond()
+    } else if (route.includes('/account/')) {
+      // Not able to find account after all retries
+      // This can happen in the case of accounts that have not been used yet
+      // or are uninitialized. Return null account to be handled by the caller
+      return { data: { account: null } }
     } else {
       if (verbose) console.log('Request was unsuccessful after all retries.')
     }
@@ -1038,9 +1043,12 @@ export async function getTransactionReceipt(hash: string) {
 */
 
 export function getFilterId(): string {
-  return '0x' + createHash('sha256')
-    .update(randomBytes(16).toString('hex') + Date.now())
-    .digest('hex')
+  return (
+    '0x' +
+    createHash('sha256')
+      .update(randomBytes(16).toString('hex') + Date.now())
+      .digest('hex')
+  )
 }
 
 export function parseFilterDetails(filter: Filter): { address: string; topics: string[] } {


### PR DESCRIPTION
https://linear.app/shm/issue/BLUE-70/rpc-bugs-in-eth-getbalance-and-eth-gettransactioncount

I came across two issues on the RPC level where for accounts that have not been initialized, calls eth_getTransactionCount and eth_getBalance fail on an nLDRPC. 

Example with nLDRPC of a dev network:
```
$: curl -X POST -H "Content-Type: application/json" --data '{"method":"eth_getTransactionCount","params":["0xc8f59951039673bD22aCA3aCa16E42ebb61D5C16"],"id":1,"jsonrpc":"2.0"}' http://34.71.92.251:8090

{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"Unable to get transaction count"}}%
```

Adds a fix for both