### PR TITLE
GOLD-103 

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,7 +75,12 @@ export async function initSyncTime() {
       host,
       timeout: 10000,
     })
-    ntpOffset = time.t
+
+    ntpOffset = Math.floor(time.t)
+
+    if (isNaN(ntpOffset)) {
+      ntpOffset = 0
+    }
     return
   }
 }


### PR DESCRIPTION
Node uses sntp to sync the time, when syncing time there's a round trip delay, essentially when we need Date.now() in shardus/shardeum, we need to account for ` Date.now() + t (delay)`

The package used to get the delay come in high precision milli sec floating point xx.xxx. Luckily shardus/core know about this and will round down.

Json rpc server does not round down. Ticket is to ensure this happen correctly.