### PR TITLE
GOLD-93: Rounded timestamp to nearest int to fix serialization error with bignint

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,7 +75,7 @@ export async function initSyncTime() {
       host,
       timeout: 10000,
     })
-    ntpOffset = time.t
+    ntpOffset = Math.floor(time.t)
     return
   }
 }


### PR DESCRIPTION
Linear Issue: https://linear.app/shm/issue/GOLD-93/serialisation-error-in-long-running-network