### PR TITLE
SYS-275 - Timed stats logging + DB improvements

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,7 @@ type Config = {
   }
   statLog: boolean
   statLogIntervalSec: number
+  statLogLimit: number
   passphrase: string
   secret_key: string
 
@@ -163,6 +164,7 @@ export const CONFIG: Config = {
   },
   statLog: false,
   statLogIntervalSec: 10,
+  statLogLimit: 10000,
   passphrase: process.env.PASSPHRASE || 'sha4d3um', // this is to protect debug routes
   secret_key: process.env.SECRET_KEY || 'YsDGSMYHkSBMGD6B4EmD?mFTWG2Wka-Z9b!Jc/CLkrM8eLsBe5abBaTSGeq?6g?P', // this is the private key that rpc server will used to sign jwt token
   adaptiveRejection: true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,6 +53,7 @@ type Config = {
     softReject: boolean
   }
   statLog: boolean
+  statLogIntervalSec: number
   passphrase: string
   secret_key: string
 
@@ -161,6 +162,7 @@ export const CONFIG: Config = {
     allowedHeavyRequestPerMin: 20, // number of eth_call + tx inject allowed within 60s
   },
   statLog: false,
+  statLogIntervalSec: 10,
   passphrase: process.env.PASSPHRASE || 'sha4d3um', // this is to protect debug routes
   secret_key: process.env.SECRET_KEY || 'YsDGSMYHkSBMGD6B4EmD?mFTWG2Wka-Z9b!Jc/CLkrM8eLsBe5abBaTSGeq?6g?P', // this is the private key that rpc server will used to sign jwt token
   adaptiveRejection: true,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -40,28 +40,27 @@ export const debug_info = {
 
 export async function saveInterfaceStat(): Promise<void> {
   console.log(apiPerfLogData)
-  try {
+  // eslint-disable-next-line prefer-const
+  let { api_name, tfinal, timestamp, nodeUrl, success, reason, hash } = apiPerfLogData[0]
+  // nodeUrl = nodeUrl ? nodeUrl : new URL(nodeUrl as string).hostname
+  let placeholders = `NULL, '${api_name}', '${tfinal}','${timestamp}', '${nodeUrl}', '${success}', '${reason}', '${hash}'`
+  let sql = 'INSERT INTO interface_stats VALUES (' + placeholders + ')'
+  for (let i = 1; i < apiPerfLogData.length; i++) {
     // eslint-disable-next-line prefer-const
-    let { api_name, tfinal, timestamp, nodeUrl, success, reason, hash } = apiPerfLogData[0]
+    let { api_name, tfinal, timestamp, nodeUrl, success, reason, hash } = apiPerfLogData[i] // eslint-disable-line security/detect-object-injection
+
     // nodeUrl = nodeUrl ? nodeUrl : new URL(nodeUrl as string).hostname
-    let placeholders = `NULL, '${api_name}', '${tfinal}','${timestamp}', '${nodeUrl}', '${success}', '${reason}', '${hash}'`
-    let sql = 'INSERT INTO interface_stats VALUES (' + placeholders + ')'
-    for (let i = 1; i < apiPerfLogData.length; i++) {
-      // eslint-disable-next-line prefer-const
-      let { api_name, tfinal, timestamp, nodeUrl, success, reason, hash } = apiPerfLogData[i] // eslint-disable-line security/detect-object-injection
+    placeholders = `NULL, '${api_name}', '${tfinal}','${timestamp}', '${nodeUrl}', '${success}', '${reason}', '${hash}'`
+    sql = sql + `, (${placeholders})`
+  }
 
-      // nodeUrl = nodeUrl ? nodeUrl : new URL(nodeUrl as string).hostname
-      placeholders = `NULL, '${api_name}', '${tfinal}','${timestamp}', '${nodeUrl}', '${success}', '${reason}', '${hash}'`
-      sql = sql + `, (${placeholders})`
-    }
+  apiPerfLogData = []
 
+  try {
     await db.exec(sql)
   } catch (e) {
     console.log(e)
   }
-
-  apiPerfLogData = []
-  apiPerfLogTicket = {}
 }
 
 export function setupLogEvents(): void {

--- a/src/routes/log.ts
+++ b/src/routes/log.ts
@@ -2,7 +2,7 @@ import { db } from '../storage/sqliteStorage'
 import express, { Request, Response } from 'express'
 export const router = express.Router()
 import { CONFIG } from '../config'
-import { debug_info } from '../logger'
+import { debug_info, getInterfaceStatCounts } from '../logger'
 
 const timeInputProcessor = (timestamp: string): number => {
   const t = timestamp.includes('-') ? timestamp : parseInt(timestamp)
@@ -370,6 +370,12 @@ router.route('/stopRPCCapture').get(async function (req: Request, res: Response)
   debug_info.interfaceRecordingEndTime = Date.now()
   CONFIG.statLog = false
   res.json({ message: 'RPC interface recording disabled' }).status(200)
+})
+router.route('/countRPCCapture').get(async function (req: Request, res: Response) {
+  if (!CONFIG.statLog) {
+    return res.json({ message: 'Interface stats recording disabled' }).status(304)
+  }
+  res.json(getInterfaceStatCounts()).status(200)
 })
 
 router.route('/status').get(async function (req: Request, res: Response) {

--- a/src/routes/log.ts
+++ b/src/routes/log.ts
@@ -355,7 +355,7 @@ router.route('/stopTxCapture').get(async function (req: Request, res: Response) 
 
 router.route('/startRPCCapture').get(async function (req: Request, res: Response) {
   if (CONFIG.statLog) {
-    return res.json({ message: 'Interface stats are recording recording already' }).status(304)
+    return res.json({ message: 'Interface stats are recording already' }).status(304)
   }
   debug_info.interfaceRecordingStartTime = Date.now()
   debug_info.interfaceRecordingEndTime = 0

--- a/src/storage/sqliteStorage.ts
+++ b/src/storage/sqliteStorage.ts
@@ -3,37 +3,45 @@ import fs from 'fs'
 
 export let db: Database.Database
 
-async function init(): Promise<void> {
+export let statements: {[name: string]:Database.Statement} = {}
+
+function init() {
   /* eslint-disable security/detect-non-literal-fs-filename */
   const dir = './log'
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir)
   }
   db = new Database(`${dir}/log.sqlite3`)
-  await db.pragma('journal_mode = WAL')
+  db.pragma('journal_mode = WAL')
   console.log('Database initialized.')
   /* eslint-enable security/detect-non-literal-fs-filename */
 }
 
-async function createTables(): Promise<void> {
-  await db.exec(
+function createTables() {
+  db.exec(
     'CREATE TABLE IF NOT EXISTS transactions ' +
       '(`id` INTEGER PRIMARY KEY AUTOINCREMENT, `hash` VARCHAR NOT NULL UNIQUE, `type` VARCHAR, `to` VARCHAR, `from` VARCHAR, `injected` BOOLEAN, `accepted` NUMBER NOT NULL, `reason` VARCHAR, `ip` VARCHAR, `timestamp` BIGINT, `nodeUrl` VARCHAR)'
   )
 
-  await db.exec(
+  db.exec(
     'CREATE TABLE IF NOT EXISTS interface_stats ' +
       '(`id` INTEGER PRIMARY KEY AUTOINCREMENT, `api_name` VARCHAR NOT NULL, `tfinal` BIGINT, `timestamp` BIGINT, `nodeUrl` VARCHAR, `success` boolean, `reason` VARCHAR, `hash` VARCHAR)'
   )
 
-  await db.exec(
+  db.exec(
     'CREATE TABLE IF NOT EXISTS gas_estimations ' +
       '(`contract_address` VARCHAR, `function_signature` VARCHAR, `gasEstimate` VARCHAR, `timestamp` BIGINT, ' +
       'PRIMARY KEY (`contract_address`, `function_signature`))'
   )
 }
 
-export async function setupDatabase(): Promise<void> {
-  await init()
-  await createTables()
+export function createPreparedStatements() {
+  statements['insertInterfaceStat'] = db.prepare('INSERT INTO interface_stats VALUES (NULL, $api_name, $tfinal, $timestamp, $nodeUrl, $success, $reason, $hash)')
+  statements['getInterfaceStatCounts'] = db.prepare('SELECT api_name, COUNT(api_name) FROM interface_stats GROUP BY api_name ORDER BY COUNT(api_name) DESC')
+}
+
+export function setupDatabase() {
+  init()
+  createTables()
+  createPreparedStatements()
 }


### PR DESCRIPTION
Stats are only logged when 10,000 transactions are received which makes using RPC stats on a small local network difficult. This PR cases the stats to be logged to the DB based on a time interval so networks with less transaction will still see stats.