### PR TITLE
SYS-291 : Fix log endpoint auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@ethersproject/bignumber": "^5.7.0",
         "@hapi/sntp": "^4.0.0",
         "@shardus/archiver-discovery": "1.1.0",
-        "@shardus/crypto-utils": "4.1.3",
+        "@shardus/crypto-utils": "4.1.4",
         "axios": "1.6.1",
         "better-sqlite3": "7.6.2",
         "body-parser": "1.19.0",
@@ -701,9 +701,9 @@
       }
     },
     "node_modules/@shardus/crypto-utils": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@shardus/crypto-utils/-/crypto-utils-4.1.3.tgz",
-      "integrity": "sha512-nvPqtw8R2uQ34MwF5CuE1xI0lx658aRELaKtxYO0b6QoLdwPGm6eO6I8KMSVZv3YJtHkx3Srs0Q/BB5/s9aRmQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@shardus/crypto-utils/-/crypto-utils-4.1.4.tgz",
+      "integrity": "sha512-TJQ6bvkUcf2QATRScg3ojTl3xcZcEpVm7+Fr+aKleK2gvZOALlDhQ6nAPSCkIEjRxwn7MF9eJ6D90BFBRr6mFg==",
       "dependencies": {
         "@shardus/types": "1.2.8",
         "buffer-xor": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@ethersproject/bignumber": "^5.7.0",
     "@hapi/sntp": "^4.0.0",
     "@shardus/archiver-discovery": "1.1.0",
-    "@shardus/crypto-utils": "4.1.3",
+    "@shardus/crypto-utils": "4.1.4",
     "axios": "1.6.1",
     "better-sqlite3": "7.6.2",
     "body-parser": "1.19.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -144,7 +144,7 @@ export const CONFIG: Config = {
   },
   aalgWarmup: false,
   aalgWarmupServiceTPS: 10,
-  recordTxStatus: false,
+  recordTxStatus: false, // not safe for production, keep this off. Known issue.
   rateLimit: false,
   rateLimitOption: {
     softReject: true,
@@ -158,7 +158,7 @@ export const CONFIG: Config = {
     releaseFromBlacklistInterval: 12, // remove banned ip from blacklist after 12 hours
     allowedHeavyRequestPerMin: 20, // number of eth_call + tx inject allowed within 60s
   },
-  statLog: false,
+  statLog: false, // not safe for production, keep this off
   passphrase: process.env.PASSPHRASE || 'sha4d3um', // this is to protect debug routes
   secret_key: process.env.SECRET_KEY || 'YsDGSMYHkSBMGD6B4EmD?mFTWG2Wka-Z9b!Jc/CLkrM8eLsBe5abBaTSGeq?6g?P', // this is the private key that rpc server will used to sign jwt token
   adaptiveRejection: true,

--- a/src/middlewares/injectIP.ts
+++ b/src/middlewares/injectIP.ts
@@ -2,7 +2,13 @@ import { CONFIG } from '../config'
 import { NextFunction, Request, Response } from 'express'
 
 const injectIP = (req: Request, res: Response, next: NextFunction): void => {
-  if (req.body.method === 'eth_sendRawTransaction' && CONFIG.recordTxStatus) req.body.params[1000] = req.ip
+  if (req.body.method === 'eth_sendRawTransaction' && CONFIG.recordTxStatus){
+    const regex_str = /^(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])(\.(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])){3}$/;
+    const regex = new RegExp(regex_str)
+    if (regex.test(req.ip)){
+      req.body.ip = req.ip
+    }
+  }
   next()
   return
 }

--- a/src/routes/log.ts
+++ b/src/routes/log.ts
@@ -121,8 +121,8 @@ const prepareSQLFilters = ({
 }
 router.route('/api-stats').get(async (req: CustomRequest, res: Response) => {
   try {
-    const page = req.query.page || 0
-    const max = req.query.max || 5000
+    const page = Number(req.query.page) || 0
+    const max = Number(req.query.max) || 5000
     const cursor: number = page * max
 
     const start = req.query.start ? timeInputProcessor(req.query.start as string) : null

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,7 +34,7 @@ import { setDefaultResultOrder } from 'dns'
 import { nestedCountersInstance } from './utils/nestedCounters'
 import { methodWhitelist } from './middlewares/methodWhitelist'
 import { isDebugModeMiddlewareLow, rateLimitedDebugAuth } from './middlewares/debugMiddleware'
-import { isIP, isIPv4 } from 'net'; 
+import { isIPv4 } from 'net'; 
 
 setDefaultResultOrder('ipv4first')
 


### PR DESCRIPTION
Adds the same auth to log stats endpoint on json-rpc-server as debug endpoints on shardeum validators.

- adds rate limiting to debug endpoints (set to 100 calls per 15 min)
