### PR TITLE
SYS-337: Create is-alive + stubbed out is-healthy endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ GET `/cleanStatTable` this endpoint trigger purging of table that store interfac
 
 GET `/cleanTxTable` this endpoint trigger purging of table that store transaction logging
 
+# Health Check
+
+GET `/is-alive` this endpoint returns 200 if the server is running.
+GET `/is-healthy` currently the same as `/is-alive` but will be expanded.
+
 # Contributing
 
 Contributions are very welcome! Everyone interacting in our codebases, issue trackers, and any other form of communication, including chat rooms and mailing lists, is expected to follow our [code of conduct](CODE_OF_CONDUCT.md) so we can all enjoy the effort we put into this project.

--- a/local_tests.patch
+++ b/local_tests.patch
@@ -1,14 +1,17 @@
-diff --git forkSrcPrefix/src/config.ts forkDstPrefix/src/config.ts
-index 8b1e6e2e2362e91b7ea955d64c287a6e61f51c48..66202ad5a7f555695c9e7cb04db7a86b0455d4a7 100644
---- forkSrcPrefix/src/config.ts
-+++ forkDstPrefix/src/config.ts
-@@ -100,7 +100,8 @@ export const CONFIG: Config = {
+diff --git a/src/config.ts b/src/config.ts
+index db6061c4..712ab94f 100644
+--- a/src/config.ts
++++ b/src/config.ts
+@@ -134,10 +134,10 @@ export const CONFIG: Config = {
    generateTxTimestamp: true,
-   nodelistRefreshInterval: 5000,
+   nodelistRefreshInterval: 30000,
    defaultRequestRetry: 5,
--  gasEstimateMethod: 'validator',
-+  staticGasEstimate: '0x2DC6C0',
-+  gasEstimateMethod: 'replayEngine',
+-  gasEstimateMethod: 'serviceValidator', //serviceValidator or replayEngine or validator
++  gasEstimateMethod: 'replayEngine', //serviceValidator or replayEngine or validator
    gasEstimateInvalidationIntervalInMs: 1000 * 60 * 60 * 2, // 2 hours
-   gasEstimateUseCache: true,
+   gasEstimateUseCache: false,
+-  staticGasEstimate: '0x5B8D80', // comment out rather than delete this line
++  staticGasEstimate: '0x2DC6C0', // comment out rather than delete this line
    defaultRequestTimeout: {
+     default: 2000,
+     contract: 7000,

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "clean-log": "rm -rf ./log",
     "lint": "eslint \"./src/**/*.ts\"",
     "update-docker-dev": "docker build -t registry.gitlab.com/shardeum/json-rpc-server:dev . --push",
-    "format-check": "prettier --check './src/**/*.ts'",
-    "format-fix": "prettier --write './src/**/*.ts'"
+    "format-check": "prettier --check \"./src/**/*.ts\"",
+    "format-fix": "prettier --write \"./src/**/*.ts\""
   },
   "author": "thantsintoe",
   "license": "ISC",

--- a/src/routes/healthCheck.ts
+++ b/src/routes/healthCheck.ts
@@ -1,0 +1,15 @@
+import express, { Request, Response, Router } from 'express'
+import { nestedCountersInstance } from '../utils/nestedCounters'
+
+export const healthCheckRouter: Router = express.Router()
+
+healthCheckRouter.get('/is-alive', (req: Request, res: Response) => {
+  nestedCountersInstance.countEvent('endpoint', 'is-alive')
+  return res.sendStatus(200)
+})
+
+healthCheckRouter.get('/is-healthy', (req: Request, res: Response) => {
+  // TODO: Add actual health check logic
+  nestedCountersInstance.countEvent('endpoint', 'health-check')
+  return res.sendStatus(200)
+})

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import {
 } from './utils'
 import { router as logRoute } from './routes/log'
 import { router as authenticate } from './routes/authenticate'
+import { healthCheckRouter } from './routes/healthCheck'
 import { Request, Response } from 'express'
 import { CONFIG, CONFIG as config } from './config'
 import blackList from '../blacklist.json'
@@ -79,13 +80,16 @@ app.set('trust proxy', true)
 app.use(cors({ methods: ['POST'] }))
 app.use(express.json())
 app.use(cookieParser())
-app.use(function(req, res, next) {
-  res.setHeader('X-Content-Type-Options', 'nosniff');
-  res.setHeader('Permissions-Policy', 'accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=(), clipboard-read=(), clipboard-write=(), gamepad=(), speaker-selection=(), conversion-measurement=(), focus-without-user-activation=(), hid=(), idle-detection=(), interest-cohort=(), serial=(), sync-script=(), trust-token-redemption=(), unload=(), window-placement=(), vertical-scroll=()');
-  res.setHeader('X-Frame-Options', 'SAMEORIGIN');
-  res.setHeader('Content-Security-Policy', "default-src 'self'");
-  next();
-});
+app.use(function (req, res, next) {
+  res.setHeader('X-Content-Type-Options', 'nosniff')
+  res.setHeader(
+    'Permissions-Policy',
+    'accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=(), clipboard-read=(), clipboard-write=(), gamepad=(), speaker-selection=(), conversion-measurement=(), focus-without-user-activation=(), hid=(), idle-detection=(), interest-cohort=(), serial=(), sync-script=(), trust-token-redemption=(), unload=(), window-placement=(), vertical-scroll=()'
+  )
+  res.setHeader('X-Frame-Options', 'SAMEORIGIN')
+  res.setHeader('Content-Security-Policy', "default-src 'self'")
+  next()
+})
 
 if (config.dashboard.enabled && config.dashboard.dist_path) {
   const clientDirectory =
@@ -114,11 +118,6 @@ app.get('/api/subscribe', authorize, (req: Request, res: Response) => {
     return
   }
   res.end(`Successfully changed to ${ip}:${port}`)
-})
-
-app.get('/api/health', (req: Request, res: Response) => {
-  nestedCountersInstance.countEvent('api', 'health')
-  return res.json({ healthy: true }).status(200)
 })
 
 app.get('/counts', authorize, (req: Request, res: Response) => {
@@ -194,6 +193,7 @@ app.use(async (req: Request, res: Response, next: NextFunction) => {
 
 app.use('/log', authorize, logRoute)
 app.use('/authenticate', authenticate)
+app.use('/', healthCheckRouter)
 app.use(injectIP)
 // reject subscription methods from http
 app.use(rejectSubscription)


### PR DESCRIPTION
This pull request adds two new endpoints, `/is-alive` and `/is-healthy`, to the existing API. The `/is-alive` endpoint returns a 200 status code if the server is running, while the `/is-healthy` endpoint will be expanded in the future.
- adds `/is-alive`
- adds `/is-healthy`
- existing `/api/health` endpoint was removed (I did not find a reference to it in any of our other repos)

changes unrelated to the ticket:
- fixed local_tests.patch not applying
- prettier formatting
- fixed npm format-fix and format-check so they work on windows as well as mac/linux