### PR TITLE
fix: Handle invalid filterId gracefully in API methods

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -2897,9 +2897,17 @@ export const methods = {
 
     logEventEmitter.emit('fn_start', ticket, api_name, performance.now())
 
-    const filterId = args[0]
+    let filterId
+    try {
+      filterId = args[0].toString()
+    } catch (e) {
+      callback({ code: -32602, message: 'Invalid filterId' }, null)
+      countFailedResponse(api_name, 'Invalid filterId')
+      logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
+      return
+    }
 
-    const internalFilter: Types.InternalFilter | undefined = filtersMap.get(filterId.toString())
+    const internalFilter: Types.InternalFilter | undefined = filtersMap.get(filterId)
     let updates: string[] = []
     if (internalFilter && internalFilter.type === Types.FilterTypes.log) {
       const logFilter = internalFilter.filter as Types.LogFilter
@@ -2980,10 +2988,18 @@ export const methods = {
       .digest('hex')
     logEventEmitter.emit('fn_start', ticket, api_name, performance.now())
 
-    const filterId = args[0]
+    let filterId
+    try {
+      filterId = args[0].toString()
+    } catch (e) {
+      callback({ code: -32602, message: 'Invalid filterId' }, null)
+      countFailedResponse(api_name, 'Invalid filterId')
+      logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
+      return
+    }
     let logs: string[] = []
 
-    const internalFilter: Types.InternalFilter | undefined = filtersMap.get(filterId.toString())
+    const internalFilter: Types.InternalFilter | undefined = filtersMap.get(filterId)
     if (internalFilter && internalFilter.type === Types.FilterTypes.log) {
       const logFilter = internalFilter.filter as Types.LogFilter
       const request: Types.LogQueryRequest = {

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -22,6 +22,9 @@ interface Request {
 }
 
 export const onConnection = async (socket: WebSocket.WebSocket): Promise<void> => {
+
+  const eth_methods = Object.freeze(methods)
+
   socket.on('message', (message: string) => {
     if (CONFIG.verbose) console.log(`Received message: ${message}`)
     nestedCountersInstance.countEvent('websocket', 'message-received')
@@ -75,7 +78,7 @@ export const onConnection = async (socket: WebSocket.WebSocket): Promise<void> =
     }
 
     const method_name = request.method as string
-    if (!methods[method_name as keyof typeof methods]) {
+    if (!eth_methods[method_name as keyof typeof eth_methods]) {
       socket.send(
         JSON.stringify({
           id: request.id,
@@ -159,7 +162,7 @@ export const onConnection = async (socket: WebSocket.WebSocket): Promise<void> =
     }
 
     // call interface handler
-    methods[method_name as keyof typeof methods](request.params, callback)
+    eth_methods[method_name as keyof typeof eth_methods](request.params, callback)
   })
 
   socket.on('close', (code, reason) => {


### PR DESCRIPTION
Linear: https://linear.app/shm/issue/GOLD-223/[bug-bounty]-33558-in-some-instances-the-socket-can-be-made-to-hang
Summary: Added try-catch blocks around the filterId to prevent socket hangup