### PR TITLE
GOLD-290 : Blacklisting of IPs in the Json RPC server which have caused timeouts

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -740,6 +740,7 @@ async function injectAndRecordTx(
             retainTimedOutEntriesForMillis
           )
           console.log(`injectAndRecordTx: transaction timed out ip: ${baseUrl}, e: ${e.message}`)
+          nestedCountersInstance.countEvent('validatorBlacklist', nodeIpPort)
         }
         if (config.verbose) console.log('injectAndRecordTx: Caught Exception: ' + e.message)
         countInjectTxRejections('Caught Exception: ' + trimInjectRejection(e.message))

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,6 +105,7 @@ type Config = {
     limit: number // max requests per IP within time window
   }
   axiosTimeoutInMs: number
+  enableBlacklistingIP: boolean
 }
 
 export type ServicePointTypes = 'aalg-warmup'
@@ -247,4 +248,5 @@ export const CONFIG: Config = {
     limit: 100, // 100 requests per IP
   },
   axiosTimeoutInMs: 3000,
+  enableBlacklistingIP: false,
 }

--- a/src/utils/TTLMap.ts
+++ b/src/utils/TTLMap.ts
@@ -1,0 +1,39 @@
+export interface TTLMapValue<T> {
+  value: T
+  expiry: number
+  timeoutId?: NodeJS.Timeout
+}
+
+export type OnExpiryCallback<T> = (key: string, value: T) => void
+
+export class TTLMap<T> {
+  private readonly map: { [key: string]: TTLMapValue<T> } = {}
+
+  public set(key: string, value: T, ttl: number, onExpiry?: OnExpiryCallback<T>): void {
+    const expiry = Date.now() + ttl
+    const timeoutId = setTimeout(() => {
+      if (onExpiry) {
+        onExpiry(key, value)
+      }
+      delete this.map[key]
+    }, ttl)
+    this.map[key] = { value, expiry, timeoutId }
+  }
+
+  public get(key: string): T | undefined {
+    const value = this.map[key]
+    if (value && value.expiry > Date.now()) {
+      return value.value
+    }
+    delete this.map[key]
+    return undefined
+  }
+
+  public delete(key: string): void {
+    const entry = this.map[key]
+    if (entry && entry.timeoutId) {
+      clearTimeout(entry.timeoutId)
+    }
+    delete this.map[key]
+  }
+}

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -1,6 +1,6 @@
 import WebSocket from 'ws'
 import EventEmitter from 'events'
-import { wrappedMethods } from '../api'
+import { methods, wrappedMethods } from '../api'
 import { logSubscriptionList } from './clients'
 import * as crypto from 'crypto'
 import { CONFIG } from '../config'


### PR DESCRIPTION
Linear: https://linear.app/shm/issue/GOLD-290/blacklisting-of-ips-in-the-json-rpc-server-which-have-caused-timeouts

The code changes introduce a new `TTLMap` class in the `utils` directory. This class is used to store blacklisted IP entries with a time-to-live (TTL) value. The TTLMap allows for the expiration of blacklisted IP entries after a certain period of time.

This change is necessary to implement the feature of blacklisting IP addresses that cause timeouts. The `TTLMap` is used to store the blacklisted IP entries along with their expiration time. When a timeout occurs, the IP address is added to the `TTLMap` with a TTL value calculated based on the Axios timeout configuration.

