### PR TITLE
SHARD-893: Clear filtersMap when it reaches maximum entries allowed

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -27,6 +27,7 @@ import {
   getSyncTime,
   removeFromNodeList,
   sanitizeIpAndPort,
+  removeOldestFilter,
 } from './utils'
 import crypto from 'crypto'
 import { logEventEmitter } from './logger'
@@ -2800,8 +2801,7 @@ export const methods = {
       type: Types.FilterTypes.block,
     }
     if (filtersMap.size >= config.maxEntriesAllowed) {
-      filtersMap.clear()
-      console.log(`filtersMap cleared after ${config.maxEntriesAllowed} entries`)
+      removeOldestFilter(filtersMap)
     }
     filtersMap.set(filterId.toString(), internalFilter)
 
@@ -2838,8 +2838,7 @@ export const methods = {
       type: Types.FilterTypes.pendingTransaction,
     }
     if (filtersMap.size >= config.maxEntriesAllowed) {
-      filtersMap.clear()
-      console.log(`filtersMap cleared after ${config.maxEntriesAllowed} entries`)
+      removeOldestFilter(filtersMap)
     }
     filtersMap.set(filterId.toString(), internalFilter)
 
@@ -2943,8 +2942,7 @@ export const methods = {
       type: Types.FilterTypes.log,
     }
     if (filtersMap.size >= config.maxEntriesAllowed) {
-      filtersMap.clear()
-      console.log(`filtersMap cleared after ${config.maxEntriesAllowed} entries`)
+      removeOldestFilter(filtersMap)
     }
     filtersMap.set(filterId.toString(), internalFilter)
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -2799,6 +2799,10 @@ export const methods = {
       unsubscribe,
       type: Types.FilterTypes.block,
     }
+    if (filtersMap.size >= config.maxEntriesAllowed) {
+      filtersMap.clear()
+      console.log(`filtersMap cleared after ${config.maxEntriesAllowed} entries`)
+    }
     filtersMap.set(filterId.toString(), internalFilter)
 
     callback(null, filterId)
@@ -2832,6 +2836,10 @@ export const methods = {
       filter: filterObj,
       unsubscribe,
       type: Types.FilterTypes.pendingTransaction,
+    }
+    if (filtersMap.size >= config.maxEntriesAllowed) {
+      filtersMap.clear()
+      console.log(`filtersMap cleared after ${config.maxEntriesAllowed} entries`)
     }
     filtersMap.set(filterId.toString(), internalFilter)
 
@@ -2933,6 +2941,10 @@ export const methods = {
       filter: filterObj,
       unsubscribe,
       type: Types.FilterTypes.log,
+    }
+    if (filtersMap.size >= config.maxEntriesAllowed) {
+      filtersMap.clear()
+      console.log(`filtersMap cleared after ${config.maxEntriesAllowed} entries`)
     }
     filtersMap.set(filterId.toString(), internalFilter)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -106,6 +106,7 @@ type Config = {
   }
   axiosTimeoutInMs: number
   enableBlacklistingIP: boolean
+  maxEntriesAllowed: number // maximum number of entries allowed for map to store
 }
 
 export type ServicePointTypes = 'aalg-warmup'
@@ -249,4 +250,5 @@ export const CONFIG: Config = {
   },
   axiosTimeoutInMs: 3000,
   enableBlacklistingIP: false,
+  maxEntriesAllowed: 10000,
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,7 @@ import {
   OriginalTxData,
   AccountTypesData,
   Account2,
+  InternalFilter
 } from './types'
 import Sntp from '@hapi/sntp'
 import { randomBytes, createHash } from 'crypto'
@@ -1836,6 +1837,24 @@ export function sanitizeIpAndPort(ipPort: string): { isValid: boolean; error?: s
   }
 
   return { isValid: true }
+}
+
+export function removeOldestFilter(filtersMap: Map<string, InternalFilter>): void {
+  let oldestKey: string | undefined;
+  let oldestTimestamp = Infinity;
+
+  // Iterate through the map to find the oldest entry
+  for (const [key, value] of filtersMap) {
+    if (value.filter.lastQueriedTimestamp < oldestTimestamp) {
+      oldestTimestamp = value.filter.lastQueriedTimestamp;
+      oldestKey = key;
+    }
+  }
+
+  // Remove the oldest entry
+  if (oldestKey !== undefined) {
+    filtersMap.delete(oldestKey);
+  }
 }
 
 class Semaphore {


### PR DESCRIPTION
The code changes in `api.ts` introduce a check to clear the `filtersMap` when it reaches the maximum number of entries allowed, as specified by the `maxEntriesAllowed` configuration value. This ensures that the `filtersMap` does not exceed the allowed size and prevents potential performance issues and DoS attacks

Linear : https://linear.app/shm/issue/SHARD-893/[bug-bounty]-35534-json-rpc-server-remote-crash