### PR TITLE
SHARD-1058: limits on socket connections, subscriptions per socket, connection timeout +fixes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,9 @@ type Config = {
   websocket: {
     enabled: boolean
     serveSubscriptions: boolean
+    maxConnections: number // Maximum number of concurrent WebSocket connections
+    maxSubscriptionsPerSocket: number // Maximum number of subscriptions per socket
+    connectionTimeoutMs: number // Connection timeout in milliseconds (default 1 day)
   }
   trustProxy: boolean // Whether to trust the X-Forwarded-For header
   log_server: {
@@ -116,6 +119,9 @@ export const CONFIG: Config = {
   websocket: {
     enabled: true,
     serveSubscriptions: Boolean(process.env.WS_SAVE_SUBSCRIPTIONS) || false,
+    maxConnections: Number(process.env.WS_MAX_CONNECTIONS) || 1000,
+    maxSubscriptionsPerSocket: Number(process.env.WS_MAX_SUBSCRIPTIONS_PER_SOCKET) || 50,
+    connectionTimeoutMs: Number(process.env.WS_CONNECTION_TIMEOUT_MS) || 24 * 60 * 60 * 1000, // 1 day in ms
   },
   trustProxy: false,
   log_server: {

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -27,7 +27,7 @@ let activeConnections = 0
 export const onConnection = async (socket: WebSocket.WebSocket): Promise<void> => {
   // Check max connections limit
   if (activeConnections >= CONFIG.websocket.maxConnections) {
-    socket.close(1013, 'Maximum number of connections reached')
+    socket.close(1003, 'Server busy. Please try again later.')
     return
   }
   activeConnections++

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -21,7 +21,22 @@ interface Request {
   params: Params
 }
 
+// Add connection counter
+let activeConnections = 0
+
 export const onConnection = async (socket: WebSocket.WebSocket): Promise<void> => {
+  // Check max connections limit
+  if (activeConnections >= CONFIG.websocket.maxConnections) {
+    socket.close(1013, 'Maximum number of connections reached')
+    return
+  }
+  activeConnections++
+
+  // Set connection timeout
+  const timeoutId = setTimeout(() => {
+    socket.close(1011, 'Connection timeout reached')
+  }, CONFIG.websocket.connectionTimeoutMs)
+
   const eth_methods = Object.freeze(wrappedMethods)
 
   socket.on('message', (message: string) => {
@@ -95,6 +110,16 @@ export const onConnection = async (socket: WebSocket.WebSocket): Promise<void> =
         socket.send(JSON.stringify(constructRPCErrorRes('Subscription serving disabled', -1, request.id)))
         return
       }
+
+      // Check subscription limit per socket
+      const currentSubscriptions = logSubscriptionList.getBySocket(socket)?.size || 0
+      if (currentSubscriptions >= CONFIG.websocket.maxSubscriptionsPerSocket) {
+        socket.send(
+          JSON.stringify(constructRPCErrorRes('Maximum subscriptions per connection reached', -1, request.id))
+        )
+        return
+      }
+
       try {
         nestedCountersInstance.countEvent('websocket', 'eth_subscribe')
         if (
@@ -165,6 +190,12 @@ export const onConnection = async (socket: WebSocket.WebSocket): Promise<void> =
   })
 
   socket.on('close', (code, reason) => {
+    // Clear timeout on close
+    clearTimeout(timeoutId)
+
+    // Decrement connection counter
+    activeConnections--
+
     console.log(`WebSocket connection closed with code: ${code} and reason: ${reason}`)
     nestedCountersInstance.countEvent('websocket', 'close')
     if (logSubscriptionList.getBySocket(socket)) {
@@ -172,8 +203,9 @@ export const onConnection = async (socket: WebSocket.WebSocket): Promise<void> =
         subscriptionEventEmitter.emit('evm_log_unsubscribe', subscription_id)
       })
       logSubscriptionList.removeBySocket(socket)
+      socket.close(code, reason)
     }
-    console.log(logSubscriptionList.getAll())
+    if(CONFIG.verbose) console.log(logSubscriptionList.getAll())
   })
 }
 

--- a/src/websocket/log_server.ts
+++ b/src/websocket/log_server.ts
@@ -66,7 +66,8 @@ export const setupEvmLogProviderConnectionStream = (): void => {
       }
       if (message.method == 'unsubscribe') {
         if (message.success) {
-          logSubscriptionList.getById(message.subscription_id)?.socket.send(
+          const socket = logSubscriptionList.getById(message.subscription_id)?.socket
+          socket?.send(
             JSON.stringify({
               jsonrpc: '2.0',
               id: logSubscriptionList.requestIdBySubscriptionId.get(message.subscription_id),
@@ -74,6 +75,11 @@ export const setupEvmLogProviderConnectionStream = (): void => {
             })
           )
           logSubscriptionList.removeById(message.subscription_id)
+
+          const socketSubscriptions = logSubscriptionList.getBySocket(socket as WebSocket.WebSocket)
+          if (socketSubscriptions === null || socketSubscriptions.size === 0) {
+            socket?.close()
+          }
         } else {
           logSubscriptionList.getById(message.subscription_id)?.socket.send(
             JSON.stringify({

--- a/test/unit/middlewares/rateLimit.test.ts
+++ b/test/unit/middlewares/rateLimit.test.ts
@@ -42,13 +42,15 @@ describe('Rate Limiting', () => {
     jest.clearAllMocks()
     // Reset config to default state
     CONFIG.rateLimit = true
+    // Mock console.error
+    jest.spyOn(console, 'error').mockImplementation(() => {})
   })
 
   it('should skip rate limiting when disabled in config', async () => {
     CONFIG.rateLimit = false
 
     const mockReq = {
-      socket: { remoteAddress: '127.0.0.1' },
+      ip: '127.0.0.1',
       body: {
         method: 'eth_call',
         params: []
@@ -72,7 +74,7 @@ describe('Rate Limiting', () => {
     jest.spyOn(requestersList, 'isRequestOkay').mockResolvedValueOnce(true)
 
     const mockReq = {
-      socket: { remoteAddress: '127.0.0.1' },
+      ip: '127.0.0.1',
       body: {
         method: 'eth_call',
         params: []
@@ -97,7 +99,7 @@ describe('Rate Limiting', () => {
       .mockResolvedValueOnce(true)
 
     const mockReq = {
-      socket: { remoteAddress: '127.0.0.1' },
+      ip: '127.0.0.1',
       body: [
         {
           method: 'eth_call',
@@ -126,7 +128,7 @@ describe('Rate Limiting', () => {
     jest.spyOn(requestersList, 'isRequestOkay').mockResolvedValue(false)
 
     const mockReq = {
-      socket: { remoteAddress: '127.0.0.1' },
+      ip: '127.0.0.1',
       body: {
         method: 'eth_sendRawTransaction',
         params: []
@@ -141,7 +143,7 @@ describe('Rate Limiting', () => {
     const mockNext = jest.fn()
 
     await rateLimitMiddleware(mockReq, mockRes, mockNext)
-    expect(mockRes.status).toHaveBeenCalledWith(503)
+    expect(mockRes.status).toHaveBeenCalledWith(429)
     expect(mockRes.send).toHaveBeenCalledWith('Rejected by rate-limiting')
     expect(mockNext).not.toHaveBeenCalled()
   })
@@ -154,7 +156,7 @@ describe('Rate Limiting', () => {
     CONFIG.rateLimitOption.softReject = true
 
     const mockReq = {
-      socket: { remoteAddress: '127.0.0.1' },
+      ip: '127.0.0.1',
       body: {
         method: 'eth_sendRawTransaction',
         params: []
@@ -181,7 +183,7 @@ describe('Rate Limiting', () => {
     jest.spyOn(requestersList, 'isRequestOkay').mockRejectedValueOnce(new Error('Mock error'))
 
     const mockReq = {
-      socket: { remoteAddress: '127.0.0.1' },
+      ip: '127.0.0.1',
       body: {
         method: 'eth_call',
         params: []
@@ -197,7 +199,7 @@ describe('Rate Limiting', () => {
 
     await rateLimitMiddleware(mockReq, mockRes, mockNext)
     expect(mockRes.status).toHaveBeenCalledWith(500)
-    expect(mockRes.send).toHaveBeenCalledWith('Internal server error during rate limiting')
+    expect(mockRes.send).toHaveBeenCalledWith('Internal server error')
     expect(mockNext).not.toHaveBeenCalled()
   })
 }) 

--- a/test/unit/websocket/index.test.ts
+++ b/test/unit/websocket/index.test.ts
@@ -1,0 +1,226 @@
+import WebSocket from 'ws'
+import { onConnection } from '../../../src/websocket'
+import { CONFIG } from '../../../src/config'
+import { logSubscriptionList } from '../../../src/websocket/clients'
+
+// Mock WebSocket
+jest.mock('ws')
+
+// Mock the entire websocket/index module
+jest.mock('../../../src/websocket', () => {
+  const originalModule = jest.requireActual('../../../src/websocket')
+  return {
+    ...originalModule,
+    activeConnections: 0,
+  }
+})
+
+// Mock the methods object from the API module
+jest.mock('../../../src/api', () => ({
+  methods: {
+    eth_getBalance: jest.fn(),
+    eth_blockNumber: jest.fn(),
+    eth_sendRawTransaction: jest.fn(),
+  },
+}))
+
+// Mock external APIs
+jest.mock('../../../src/external/Collector', () => ({
+  collectorAPI: {
+    fetchAccount: jest.fn(),
+    getBlock: jest.fn(),
+    getTransactionByHash: jest.fn(),
+  },
+}))
+
+jest.mock('../../../src/websocket/log_server', () => ({
+  evmLogProvider_ConnectionStream: jest.fn(),
+}))
+
+describe('WebSocket Connection Tests', () => {
+  let mockSocket: jest.Mocked<WebSocket>
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    mockSocket = {
+      on: jest.fn(),
+      send: jest.fn(),
+      close: jest.fn(),
+      readyState: WebSocket.OPEN,
+    } as unknown as jest.Mocked<WebSocket>
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    jest.clearAllTimers()
+  })
+
+  describe('Connection Timeout', () => {
+    it('should close connection after timeout period', async () => {
+      // Clear any existing mocks
+      jest.clearAllMocks()
+
+      // Import the mocked module
+      const websocketModule = require('../../../src/websocket')
+      websocketModule.activeConnections = 0
+
+      await onConnection(mockSocket)
+
+      // Fast forward past the timeout
+      jest.advanceTimersByTime(CONFIG.websocket.connectionTimeoutMs + 100)
+
+      // Verify the close was called with timeout message
+      expect(mockSocket.close).toHaveBeenCalledTimes(1)
+      expect(mockSocket.close).toHaveBeenCalledWith(1011, 'Connection timeout reached')
+
+      // Verify activeConnections was decremented
+      expect(websocketModule.activeConnections).toBe(0)
+    })
+
+    it('should clear timeout when connection closes normally', async () => {
+      // Mock logSubscriptionList.getBySocket to return a Set
+      jest.spyOn(logSubscriptionList, 'getBySocket').mockImplementation(() => new Set(['dummy-subscription']))
+      await onConnection(mockSocket)
+
+      // Simulate connection close
+      const closeCallbackEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'close')
+
+      if (closeCallbackEntry) {
+        const closeCallback = closeCallbackEntry[1].bind(mockSocket)
+        closeCallback(1000, 'Normal close')
+      }
+
+      // Fast forward past the timeout
+      jest.advanceTimersByTime(CONFIG.websocket.connectionTimeoutMs + 100)
+
+      // Close should have been called once for the normal close, not for timeout
+      expect(mockSocket.close).toHaveBeenCalledWith(1000, 'Normal close')
+    })
+  })
+
+  describe('Connection Limits', () => {
+    it('should accept connections when below max limit', async () => {
+      await onConnection(mockSocket)
+      expect(mockSocket.close).not.toHaveBeenCalled()
+    })
+
+    it('should reject connections when at max limit', async () => {
+      // Create max number of connections
+      for (let i = 0; i < CONFIG.websocket.maxConnections; i++) {
+        await onConnection(mockSocket)
+      }
+
+      // Try one more connection
+      await onConnection(mockSocket)
+      expect(mockSocket.close).toHaveBeenCalledWith(1013, 'Maximum number of connections reached')
+    })
+  })
+
+  describe('Subscription Limits', () => {
+    it('should reject subscriptions when at max limit per socket', async () => {
+      await onConnection(mockSocket)
+
+      // Get the message handler
+      const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
+      if (messageHandlerEntry) {
+        const messageHandler = messageHandlerEntry[1].bind(mockSocket)
+
+        // Mock subscription list
+        jest.spyOn(logSubscriptionList, 'getBySocket').mockImplementation(() => new Set(['sub1', 'sub2']))
+
+        // Attempt to subscribe
+        const subscribeRequest = {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'eth_subscribe',
+          params: [{}, { address: '0x123' }],
+        }
+
+        messageHandler(JSON.stringify(subscribeRequest))
+
+        expect(mockSocket.send).toHaveBeenCalledWith(
+          expect.stringContaining('Maximum subscriptions per connection reached')
+        )
+      }
+    })
+
+    it('should accept subscriptions when below max limit', async () => {
+      await onConnection(mockSocket)
+
+      // Get the message handler
+      const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
+      if (messageHandlerEntry) {
+        const messageHandler = messageHandlerEntry[1].bind(mockSocket)
+
+        // Mock subscription list to return fewer than max subscriptions
+        jest.spyOn(logSubscriptionList, 'getBySocket').mockImplementation(() => new Set(['sub1']))
+
+        // Attempt to subscribe
+        const subscribeRequest = {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'eth_subscribe',
+          params: [{}, { address: '0x123' }],
+        }
+
+        messageHandler(JSON.stringify(subscribeRequest))
+
+        expect(mockSocket.send).not.toHaveBeenCalledWith(
+          expect.stringContaining('Maximum subscriptions per connection reached')
+        )
+      }
+    })
+  })
+
+  describe('Error Handling', () => {
+    it('should handle invalid JSON messages', async () => {
+      await onConnection(mockSocket)
+
+      const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
+      if (messageHandlerEntry) {
+        const messageHandler = messageHandlerEntry[1].bind(mockSocket)
+        messageHandler('invalid json')
+        expect(mockSocket.close).toHaveBeenCalled()
+      }
+    })
+
+    it('should handle invalid RPC version', async () => {
+      await onConnection(mockSocket)
+
+      const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
+      if (messageHandlerEntry) {
+        const messageHandler = messageHandlerEntry[1].bind(mockSocket)
+
+        const invalidRequest = {
+          jsonrpc: '1.0',
+          id: 1,
+          method: 'eth_subscribe',
+          params: [],
+        }
+
+        messageHandler(JSON.stringify(invalidRequest))
+
+        expect(mockSocket.close).toHaveBeenCalledWith(1002, 'Invalid rpc socket frame')
+      }
+    })
+  })
+
+  describe('Connection Cleanup', () => {
+    it('should clean up resources on connection close', async () => {
+      await onConnection(mockSocket)
+
+      const closeHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'close')
+      if (closeHandlerEntry) {
+        const closeHandler = closeHandlerEntry[1].bind(mockSocket)
+
+        // Mock subscription list
+        jest.spyOn(logSubscriptionList, 'getBySocket').mockImplementation(() => new Set(['sub1']))
+        jest.spyOn(logSubscriptionList, 'removeBySocket').mockImplementation(() => {})
+
+        closeHandler(1000, 'Normal close')
+
+        expect(logSubscriptionList.removeBySocket).toHaveBeenCalledWith(mockSocket)
+      }
+    })
+  })
+})

--- a/test/unit/websocket/index.test.ts
+++ b/test/unit/websocket/index.test.ts
@@ -112,7 +112,7 @@ describe('WebSocket Connection Tests', () => {
 
       // Try one more connection
       await onConnection(mockSocket)
-      expect(mockSocket.close).toHaveBeenCalledWith(1013, 'Maximum number of connections reached')
+      expect(mockSocket.close).toHaveBeenCalledWith(1003, 'Server busy. Please try again later.')
     })
   })
 


### PR DESCRIPTION
Linear: https://linear.app/shm/issue/SHARD-1058/
Summary:
This PR introduces the following changes:

1. Added limits on open socket connections, subscriptions per socket, and a one-day timeout for connections.
2. Enabled automatic closure of socket connections without active subscribers.
3. Fixed issues in the ratelimit middleware unit test.