### PR TITLE
SHARD-1058: Add per-IP connection limit to WebSocket server

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ type Config = {
     inactivityTimeoutMs: number // 60 seconds inactivity timeout
     inactivityCheckIntervalMs: number // Check every 10 seconds
     maxConnectionsPerIP: number // Maximum number of connections allowed per IP per socket
+    cleanupIntervalMs: number // Cleanup interval in milliseconds (default 10 minutes)
   }
   trustProxy: boolean // Whether to trust the X-Forwarded-For header
   log_server: {
@@ -127,7 +128,8 @@ export const CONFIG: Config = {
     connectionTimeoutMs: Number(process.env.WS_CONNECTION_TIMEOUT_MS) || 24 * 60 * 60 * 1000, // 1 day in ms
     inactivityTimeoutMs: 60000, // 60 seconds inactivity timeout
     inactivityCheckIntervalMs: 10000, // Check every 10 seconds
-    maxConnectionsPerIP: Number(process.env.WS_MAX_CONNECTIONS_PER_IP) || 50,
+    maxConnectionsPerIP: Number(process.env.WS_MAX_CONNECTIONS_PER_IP) || 3,
+    cleanupIntervalMs: Number(process.env.WS_CLEANUP_INTERVAL_MS) || 600000, // 10 minute in ms
   },
   trustProxy: false,
   log_server: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ type Config = {
     connectionTimeoutMs: number // Connection timeout in milliseconds (default 1 day)
     inactivityTimeoutMs: number // 60 seconds inactivity timeout
     inactivityCheckIntervalMs: number // Check every 10 seconds
+    maxConnectionsPerIP: number // Maximum number of connections allowed per IP per socket
   }
   trustProxy: boolean // Whether to trust the X-Forwarded-For header
   log_server: {
@@ -126,6 +127,7 @@ export const CONFIG: Config = {
     connectionTimeoutMs: Number(process.env.WS_CONNECTION_TIMEOUT_MS) || 24 * 60 * 60 * 1000, // 1 day in ms
     inactivityTimeoutMs: 60000, // 60 seconds inactivity timeout
     inactivityCheckIntervalMs: 10000, // Check every 10 seconds
+    maxConnectionsPerIP: Number(process.env.WS_MAX_CONNECTIONS_PER_IP) || 50,
   },
   trustProxy: false,
   log_server: {

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -36,18 +36,33 @@ setInterval(() => {
     }
   })
 }, CONFIG.websocket.inactivityCheckIntervalMs)
+const connectionsByIP = new Map<string, number>()
 
-export const onConnection = async (socket: WebSocket.WebSocket): Promise<void> => {
-  // Check max connections limit
-  if (activeConnections >= CONFIG.websocket.maxConnections) {
-    socket.close(1003, 'Server busy. Please try again later.')
+export const onConnection = async (socket: WebSocket.WebSocket, req: any): Promise<void> => {
+  const ip = req.socket.remoteAddress
+  if (!ip) {
+    socket.close(
+      1008,
+      'Connection closed: Unable to determine your IP address. Please check your network settings and try again.'
+    )
+    return
+  }
+
+  const currentIPConnections = connectionsByIP.get(ip) || 0
+
+  // Check max connections per IP limit
+  if (currentIPConnections >= CONFIG.websocket.maxConnectionsPerIP) {
+    socket.close(
+      1008,
+      `Connection closed: Your IP address has reached the maximum allowed connections. Please close an existing connection or try again later.`
+    )
     return
   }
   activeConnections++
 
   // Track last activity time
   socketActivityMap.set(socket, Date.now())
-
+  connectionsByIP.set(ip, currentIPConnections + 1)
   // Set connection timeout
   const timeoutId = setTimeout(() => {
     socket.close(1011, 'Connection timeout reached')
@@ -216,6 +231,13 @@ export const onConnection = async (socket: WebSocket.WebSocket): Promise<void> =
     // Decrement connection counter
     activeConnections--
 
+    const currentIPConnections = connectionsByIP.get(ip) || 0
+    if (currentIPConnections > 0) {
+      connectionsByIP.set(ip, currentIPConnections - 1)
+    }
+    if (currentIPConnections === 0) {
+      connectionsByIP.delete(ip)
+    }
     console.log(`WebSocket connection closed with code: ${code} and reason: ${reason}`)
     nestedCountersInstance.countEvent('websocket', 'close')
     if (logSubscriptionList.getBySocket(socket)) {

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -347,13 +347,23 @@ const cleanupIntervalMs = CONFIG.websocket.cleanupIntervalMs; // Run cleanup eve
 
 const cleanupStaleConnections = () => {
   connectionsByIP.forEach((sockets, ip) => {
+    // Collect sockets to be removed in a separate array
+    const socketsToRemove: WebSocket.WebSocket[] = [];
+
     sockets.forEach((socket) => {
       if (socket.readyState === WebSocket.CLOSED || socket.readyState === WebSocket.CLOSING) {
-        sockets.delete(socket);
+        // Add socket to removal list instead of deleting directly
+        socketsToRemove.push(socket);
         activeConnections--;
       }
     });
 
+    // Remove sockets after iteration to avoid concurrent modification
+    socketsToRemove.forEach((socket) => {
+      sockets.delete(socket);
+    });
+
+    // Remove IP entry if no sockets remain
     if (sockets.size === 0) {
       connectionsByIP.delete(ip);
     }

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -354,13 +354,13 @@ const cleanupStaleConnections = () => {
       if (socket.readyState === WebSocket.CLOSED || socket.readyState === WebSocket.CLOSING) {
         // Add socket to removal list instead of deleting directly
         socketsToRemove.push(socket);
-        activeConnections--;
       }
     });
 
     // Remove sockets after iteration to avoid concurrent modification
     socketsToRemove.forEach((socket) => {
       sockets.delete(socket);
+      activeConnections--;
     });
 
     // Remove IP entry if no sockets remain

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -8,6 +8,7 @@ import { ipport } from '../server'
 import { evmLogProvider_ConnectionStream } from './log_server'
 import { SubscriptionDetails } from './clients'
 import { nestedCountersInstance } from '../utils/nestedCounters'
+import { IncomingMessage } from 'http'
 
 interface Params {
   address?: string | string[]
@@ -36,9 +37,9 @@ setInterval(() => {
     }
   })
 }, CONFIG.websocket.inactivityCheckIntervalMs)
-const connectionsByIP = new Map<string, number>()
+const connectionsByIP = new Map<string, Set<WebSocket.WebSocket>>()
 
-export const onConnection = async (socket: WebSocket.WebSocket, req: any): Promise<void> => {
+export const onConnection = async (socket: WebSocket.WebSocket, req: IncomingMessage): Promise<void> => {
   const ip = req.socket.remoteAddress
   if (!ip) {
     socket.close(
@@ -48,10 +49,10 @@ export const onConnection = async (socket: WebSocket.WebSocket, req: any): Promi
     return
   }
 
-  const currentIPConnections = connectionsByIP.get(ip) || 0
+  const currentIPConnections = connectionsByIP.get(ip) || new Set()
 
   // Check max connections per IP limit
-  if (currentIPConnections >= CONFIG.websocket.maxConnectionsPerIP) {
+  if (currentIPConnections.size >= CONFIG.websocket.maxConnectionsPerIP) {
     socket.close(
       1008,
       `Connection closed: Your IP address has reached the maximum allowed connections. Please close an existing connection or try again later.`
@@ -62,7 +63,9 @@ export const onConnection = async (socket: WebSocket.WebSocket, req: any): Promi
 
   // Track last activity time
   socketActivityMap.set(socket, Date.now())
-  connectionsByIP.set(ip, currentIPConnections + 1)
+  currentIPConnections.add(socket)
+  connectionsByIP.set(ip, currentIPConnections)
+
   // Set connection timeout
   const timeoutId = setTimeout(() => {
     socket.close(1011, 'Connection timeout reached')
@@ -226,20 +229,20 @@ export const onConnection = async (socket: WebSocket.WebSocket, req: any): Promi
   socket.on('close', (code, reason) => {
     // Clean up
     socketActivityMap.delete(socket)
-    clearTimeout(timeoutId)
+    clearTimeout(timeoutId);
 
     // Decrement connection counter
-    activeConnections--
+    activeConnections--;
 
-    const currentIPConnections = connectionsByIP.get(ip) || 0
-    if (currentIPConnections > 0) {
-      connectionsByIP.set(ip, currentIPConnections - 1)
+    const currentIPConnections = connectionsByIP.get(ip);
+    if (currentIPConnections) {
+      currentIPConnections.delete(socket);
+      if (currentIPConnections.size === 0) {
+        connectionsByIP.delete(ip);
+      }
     }
-    if (currentIPConnections === 0) {
-      connectionsByIP.delete(ip)
-    }
-    console.log(`WebSocket connection closed with code: ${code} and reason: ${reason}`)
-    nestedCountersInstance.countEvent('websocket', 'close')
+    console.log(`WebSocket connection closed with code: ${code} and reason: ${reason}`);
+    nestedCountersInstance.countEvent('websocket', 'close');
     if (logSubscriptionList.getBySocket(socket)) {
       logSubscriptionList.getBySocket(socket)?.forEach((subscription_id) => {
         subscriptionEventEmitter.emit('evm_log_unsubscribe', subscription_id)
@@ -339,3 +342,27 @@ const constructRPCErrorRes = (
     },
   }
 }
+
+const cleanupIntervalMs = CONFIG.websocket.cleanupIntervalMs; // Run cleanup every 10 minutes
+
+const cleanupStaleConnections = () => {
+  connectionsByIP.forEach((sockets, ip) => {
+    sockets.forEach((socket) => {
+      if (socket.readyState === WebSocket.CLOSED || socket.readyState === WebSocket.CLOSING) {
+        sockets.delete(socket);
+        activeConnections--;
+      }
+    });
+
+    if (sockets.size === 0) {
+      connectionsByIP.delete(ip);
+    }
+  });
+
+  if (CONFIG.verbose) {
+    console.log('Cleanup completed. Active connections:', activeConnections);
+  }
+};
+
+// Start the periodic cleanup
+setInterval(cleanupStaleConnections, cleanupIntervalMs);

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -59,6 +59,11 @@ export const onConnection = async (socket: WebSocket.WebSocket, req: IncomingMes
     )
     return
   }
+  // Check max connections limit
+  if (activeConnections >= CONFIG.websocket.maxConnections) {
+    socket.close(1003, 'Server busy. Please try again later.')
+    return
+  }
   activeConnections++
 
   // Track last activity time
@@ -229,10 +234,10 @@ export const onConnection = async (socket: WebSocket.WebSocket, req: IncomingMes
   socket.on('close', (code, reason) => {
     // Clean up
     socketActivityMap.delete(socket)
-    clearTimeout(timeoutId);
+    clearTimeout(timeoutId)
 
     // Decrement connection counter
-    activeConnections--;
+    activeConnections--
 
     const currentIPConnections = connectionsByIP.get(ip);
     if (currentIPConnections) {
@@ -250,7 +255,7 @@ export const onConnection = async (socket: WebSocket.WebSocket, req: IncomingMes
       logSubscriptionList.removeBySocket(socket)
       socket.close(code, reason)
     }
-    if (CONFIG.verbose) console.log(logSubscriptionList.getAll())
+    if (CONFIG.verbose) console.log('Current WebSocket subscriptions after connection close:', logSubscriptionList.getAll());
   })
 }
 

--- a/test/unit/websocket/index.test.ts
+++ b/test/unit/websocket/index.test.ts
@@ -2,6 +2,7 @@ import WebSocket from 'ws'
 import { onConnection } from '../../../src/websocket'
 import { CONFIG } from '../../../src/config'
 import { logSubscriptionList } from '../../../src/websocket/clients'
+import { IncomingMessage } from 'http'
 
 // Mock WebSocket
 jest.mock('ws')
@@ -64,7 +65,7 @@ describe('WebSocket Connection Tests', () => {
       const websocketModule = require('../../../src/websocket')
       websocketModule.activeConnections = 0
 
-      await onConnection(mockSocket, { socket: mockSocket })
+      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
 
       // Fast forward past the timeout
       jest.advanceTimersByTime(CONFIG.websocket.connectionTimeoutMs + 100)
@@ -80,7 +81,7 @@ describe('WebSocket Connection Tests', () => {
     it('should clear timeout when connection closes normally', async () => {
       // Mock logSubscriptionList.getBySocket to return a Set
       jest.spyOn(logSubscriptionList, 'getBySocket').mockImplementation(() => new Set(['dummy-subscription']))
-      await onConnection(mockSocket, { socket: mockSocket })
+      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
 
       // Simulate connection close
       const closeCallbackEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'close')
@@ -100,25 +101,25 @@ describe('WebSocket Connection Tests', () => {
 
   describe('Connection Limits', () => {
     it('should accept connections when below max limit', async () => {
-      await onConnection(mockSocket, { socket: mockSocket })
+      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
       expect(mockSocket.close).not.toHaveBeenCalled()
     })
 
     it('should reject connections when at max limit', async () => {
       // Create max number of connections
       for (let i = 0; i < CONFIG.websocket.maxConnections; i++) {
-        await onConnection(mockSocket, { socket: mockSocket })
+        await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
       }
 
       // Try one more connection
-      await onConnection(mockSocket, { socket: mockSocket })
+      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
       expect(mockSocket.close).toHaveBeenCalledWith(1003, 'Server busy. Please try again later.')
     })
   })
 
   describe('Subscription Limits', () => {
     it('should reject subscriptions when at max limit per socket', async () => {
-      await onConnection(mockSocket, { socket: mockSocket })
+      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
 
       // Get the message handler
       const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
@@ -145,7 +146,7 @@ describe('WebSocket Connection Tests', () => {
     })
 
     it('should accept subscriptions when below max limit', async () => {
-      await onConnection(mockSocket, { socket: mockSocket })
+      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
 
       // Get the message handler
       const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
@@ -174,7 +175,7 @@ describe('WebSocket Connection Tests', () => {
 
   describe('Error Handling', () => {
     it('should handle invalid JSON messages', async () => {
-      await onConnection(mockSocket, { socket: mockSocket })
+      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
 
       const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
       if (messageHandlerEntry) {
@@ -185,7 +186,7 @@ describe('WebSocket Connection Tests', () => {
     })
 
     it('should handle invalid RPC version', async () => {
-      await onConnection(mockSocket, { socket: mockSocket })
+      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
 
       const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
       if (messageHandlerEntry) {
@@ -207,7 +208,7 @@ describe('WebSocket Connection Tests', () => {
 
   describe('Connection Cleanup', () => {
     it('should clean up resources on connection close', async () => {
-      await onConnection(mockSocket, { socket: mockSocket })
+      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
 
       const closeHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'close')
       if (closeHandlerEntry) {

--- a/test/unit/websocket/index.test.ts
+++ b/test/unit/websocket/index.test.ts
@@ -38,17 +38,36 @@ jest.mock('../../../src/websocket/log_server', () => ({
   evmLogProvider_ConnectionStream: jest.fn(),
 }))
 
+interface MockWebSocket extends jest.Mocked<WebSocket> {
+  closeCallback: (code: number, reason: string) => void;
+}
+
 describe('WebSocket Connection Tests', () => {
-  let mockSocket: jest.Mocked<WebSocket>
+  let mockSocket: MockWebSocket
+  let mockIncomingMessage: Partial<IncomingMessage>
 
   beforeEach(() => {
     jest.useFakeTimers()
     mockSocket = {
-      on: jest.fn(),
+      on: jest.fn((event, callback) => {
+        // Store the callback for 'close' event
+        if (event === 'close') {
+          mockSocket.closeCallback = callback;
+        }
+      }),
       send: jest.fn(),
       close: jest.fn(),
       readyState: WebSocket.OPEN,
-    } as unknown as jest.Mocked<WebSocket>
+      // Add storage for close callback
+      closeCallback: null as any,
+    } as unknown as MockWebSocket
+
+    // Mock IncomingMessage with a valid IP address
+    mockIncomingMessage = {
+      socket: {
+        remoteAddress: '127.0.0.1'
+      }
+    } as Partial<IncomingMessage>
   })
 
   afterEach(() => {
@@ -65,7 +84,7 @@ describe('WebSocket Connection Tests', () => {
       const websocketModule = require('../../../src/websocket')
       websocketModule.activeConnections = 0
 
-      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
+      await onConnection(mockSocket, mockIncomingMessage as IncomingMessage)
 
       // Fast forward past the timeout
       jest.advanceTimersByTime(CONFIG.websocket.connectionTimeoutMs + 100)
@@ -79,47 +98,42 @@ describe('WebSocket Connection Tests', () => {
     })
 
     it('should clear timeout when connection closes normally', async () => {
-      // Mock logSubscriptionList.getBySocket to return a Set
-      jest.spyOn(logSubscriptionList, 'getBySocket').mockImplementation(() => new Set(['dummy-subscription']))
-      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
+      await onConnection(mockSocket, mockIncomingMessage as IncomingMessage)
 
-      // Simulate connection close
-      const closeCallbackEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'close')
-
-      if (closeCallbackEntry) {
-        const closeCallback = closeCallbackEntry[1].bind(mockSocket)
-        closeCallback(1000, 'Normal close')
+      // Simulate connection close using the stored callback
+      if (mockSocket.closeCallback) {
+        // Call the close callback directly
+        mockSocket.closeCallback(1000, 'Normal close')
       }
 
       // Fast forward past the timeout
       jest.advanceTimersByTime(CONFIG.websocket.connectionTimeoutMs + 100)
 
-      // Close should have been called once for the normal close, not for timeout
-      expect(mockSocket.close).toHaveBeenCalledWith(1000, 'Normal close')
+      // Verify that close was not called again after the timeout
+      expect(mockSocket.close).not.toHaveBeenCalled()
     })
   })
 
   describe('Connection Limits', () => {
     it('should accept connections when below max limit', async () => {
-      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
+      await onConnection(mockSocket, mockIncomingMessage as IncomingMessage)
       expect(mockSocket.close).not.toHaveBeenCalled()
     })
 
     it('should reject connections when at max limit', async () => {
       // Create max number of connections
       for (let i = 0; i < CONFIG.websocket.maxConnections; i++) {
-        await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
+        await onConnection(mockSocket, mockIncomingMessage as IncomingMessage)
       }
 
-      // Try one more connection
-      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
-      expect(mockSocket.close).toHaveBeenCalledWith(1003, 'Server busy. Please try again later.')
+      await onConnection(mockSocket, mockIncomingMessage as IncomingMessage)
+      expect(mockSocket.close).toHaveBeenCalledWith(1008, 'Connection closed: Your IP address has reached the maximum allowed connections. Please close an existing connection or try again later.')
     })
   })
 
   describe('Subscription Limits', () => {
     it('should reject subscriptions when at max limit per socket', async () => {
-      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
+      await onConnection(mockSocket, mockIncomingMessage as IncomingMessage)
 
       // Get the message handler
       const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
@@ -146,7 +160,7 @@ describe('WebSocket Connection Tests', () => {
     })
 
     it('should accept subscriptions when below max limit', async () => {
-      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
+      await onConnection(mockSocket, mockIncomingMessage as IncomingMessage)
 
       // Get the message handler
       const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
@@ -175,7 +189,7 @@ describe('WebSocket Connection Tests', () => {
 
   describe('Error Handling', () => {
     it('should handle invalid JSON messages', async () => {
-      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
+      await onConnection(mockSocket, mockIncomingMessage as IncomingMessage)
 
       const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
       if (messageHandlerEntry) {
@@ -186,7 +200,7 @@ describe('WebSocket Connection Tests', () => {
     })
 
     it('should handle invalid RPC version', async () => {
-      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
+      await onConnection(mockSocket, mockIncomingMessage as IncomingMessage)
 
       const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
       if (messageHandlerEntry) {
@@ -208,7 +222,7 @@ describe('WebSocket Connection Tests', () => {
 
   describe('Connection Cleanup', () => {
     it('should clean up resources on connection close', async () => {
-      await onConnection(mockSocket, { socket: mockSocket } as unknown as IncomingMessage)
+      await onConnection(mockSocket, mockIncomingMessage as IncomingMessage)
 
       const closeHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'close')
       if (closeHandlerEntry) {

--- a/test/unit/websocket/index.test.ts
+++ b/test/unit/websocket/index.test.ts
@@ -64,7 +64,7 @@ describe('WebSocket Connection Tests', () => {
       const websocketModule = require('../../../src/websocket')
       websocketModule.activeConnections = 0
 
-      await onConnection(mockSocket)
+      await onConnection(mockSocket, { socket: mockSocket })
 
       // Fast forward past the timeout
       jest.advanceTimersByTime(CONFIG.websocket.connectionTimeoutMs + 100)
@@ -80,7 +80,7 @@ describe('WebSocket Connection Tests', () => {
     it('should clear timeout when connection closes normally', async () => {
       // Mock logSubscriptionList.getBySocket to return a Set
       jest.spyOn(logSubscriptionList, 'getBySocket').mockImplementation(() => new Set(['dummy-subscription']))
-      await onConnection(mockSocket)
+      await onConnection(mockSocket, { socket: mockSocket })
 
       // Simulate connection close
       const closeCallbackEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'close')
@@ -100,25 +100,25 @@ describe('WebSocket Connection Tests', () => {
 
   describe('Connection Limits', () => {
     it('should accept connections when below max limit', async () => {
-      await onConnection(mockSocket)
+      await onConnection(mockSocket, { socket: mockSocket })
       expect(mockSocket.close).not.toHaveBeenCalled()
     })
 
     it('should reject connections when at max limit', async () => {
       // Create max number of connections
       for (let i = 0; i < CONFIG.websocket.maxConnections; i++) {
-        await onConnection(mockSocket)
+        await onConnection(mockSocket, { socket: mockSocket })
       }
 
       // Try one more connection
-      await onConnection(mockSocket)
+      await onConnection(mockSocket, { socket: mockSocket })
       expect(mockSocket.close).toHaveBeenCalledWith(1003, 'Server busy. Please try again later.')
     })
   })
 
   describe('Subscription Limits', () => {
     it('should reject subscriptions when at max limit per socket', async () => {
-      await onConnection(mockSocket)
+      await onConnection(mockSocket, { socket: mockSocket })
 
       // Get the message handler
       const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
@@ -145,7 +145,7 @@ describe('WebSocket Connection Tests', () => {
     })
 
     it('should accept subscriptions when below max limit', async () => {
-      await onConnection(mockSocket)
+      await onConnection(mockSocket, { socket: mockSocket })
 
       // Get the message handler
       const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
@@ -174,7 +174,7 @@ describe('WebSocket Connection Tests', () => {
 
   describe('Error Handling', () => {
     it('should handle invalid JSON messages', async () => {
-      await onConnection(mockSocket)
+      await onConnection(mockSocket, { socket: mockSocket })
 
       const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
       if (messageHandlerEntry) {
@@ -185,7 +185,7 @@ describe('WebSocket Connection Tests', () => {
     })
 
     it('should handle invalid RPC version', async () => {
-      await onConnection(mockSocket)
+      await onConnection(mockSocket, { socket: mockSocket })
 
       const messageHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'message')
       if (messageHandlerEntry) {
@@ -207,7 +207,7 @@ describe('WebSocket Connection Tests', () => {
 
   describe('Connection Cleanup', () => {
     it('should clean up resources on connection close', async () => {
-      await onConnection(mockSocket)
+      await onConnection(mockSocket, { socket: mockSocket })
 
       const closeHandlerEntry = mockSocket.on.mock.calls.find((call) => call[0] === 'close')
       if (closeHandlerEntry) {


### PR DESCRIPTION
Linear: https://linear.app/shm/issue/SHARD-1058

Summary:

1. Introduced a new configuration option `maxConnectionsPerIP` to limit the number of concurrent WebSocket connections from a single IP address.
2. Updated the `onConnection` function to check the number of active connections per IP and close the socket if the limit is reached. 
3. Periodic cleanup of stale connections.
4. Modified unit tests to accommodate the new IP connection limit functionality.