### PR TITLE
SHARD-1147: Make heavy request limits configurable and enhance logging

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -955,9 +955,9 @@ export class RequestersList {
     this.addHeavyRequest(ip)
     const heavyReqHistory = this.heavyRequests.get(ip)
 
-    if (heavyReqHistory && heavyReqHistory.length >= 61) {
-      if (now - heavyReqHistory[heavyReqHistory.length - 61] < oneMinute) {
-        if (verbose) console.log(`Ban this ip ${ip} due to continuously sending more than 60 reqs in 60s`)
+    if (heavyReqHistory && heavyReqHistory.length >= config.rateLimitOption.allowedHeavyRequestPerMin + 1) {
+      if (now - heavyReqHistory[heavyReqHistory.length - config.rateLimitOption.allowedHeavyRequestPerMin] < oneMinute) {
+        if (verbose) console.log(`Ban this ip ${ip} due to continuously sending more than ${config.rateLimitOption.allowedHeavyRequestPerMin} reqs in 60s`)
         this.addToBlacklist(ip)
         if (config.recordTxStatus && reqType === 'eth_sendRawTransaction') {
           const transaction = getTransactionObj({ raw: reqParams[0] })


### PR DESCRIPTION
Linear: https://linear.app/shm/issue/SHARD-1147
Summary:
Previously, setting config.rateLimitOption.allowedHeavyRequestPerMin to 61 or higher was ineffective because of the hard-coded rate limiting logic for heavy requests. This update removes those restrictions, making it easier to adjust heavy request thresholds as needed.