### PR TITLE
SHARD-1185: Handle WebSocket send errors to prevent crashes on closed sockets

### DIFF
--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -106,7 +106,11 @@ export const onConnection = async (socket: WebSocket.WebSocket, req: IncomingMes
       try {
         request = JSON.parse(message)
       } catch (e) {
-        socket.send('Invalid message format')
+        try {
+          socket.send('Invalid message format')
+        } catch (error) {
+          console.error('Failed to send message on WebSocket:', error)
+        }
         return
       }
 
@@ -170,7 +174,11 @@ export const onConnection = async (socket: WebSocket.WebSocket, req: IncomingMes
             code: -1,
           },
         }
-        socket.send(JSON.stringify(err_res_obj))
+        try {
+          socket.send(JSON.stringify(err_res_obj))
+        } catch (error) {
+          console.error('Failed to send message on WebSocket:', error)
+        }
         return
       }
       const res_obj = {
@@ -178,7 +186,11 @@ export const onConnection = async (socket: WebSocket.WebSocket, req: IncomingMes
         jsonrpc: '2.0',
         result: result,
       }
-      socket.send(JSON.stringify(res_obj))
+      try {
+        socket.send(JSON.stringify(res_obj))
+      } catch (error) {
+        console.error('Failed to send message on WebSocket:', error)
+      }
       return
     }
 

--- a/src/websocket/log_server.ts
+++ b/src/websocket/log_server.ts
@@ -67,13 +67,17 @@ export const setupEvmLogProviderConnectionStream = (): void => {
       if (message.method == 'unsubscribe') {
         if (message.success) {
           const socket = logSubscriptionList.getById(message.subscription_id)?.socket
-          socket?.send(
-            JSON.stringify({
-              jsonrpc: '2.0',
-              id: logSubscriptionList.requestIdBySubscriptionId.get(message.subscription_id),
-              result: true,
-            })
-          )
+          try {
+            socket?.send(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                id: logSubscriptionList.requestIdBySubscriptionId.get(message.subscription_id),
+                result: true,
+              })
+            )
+          } catch (error) {
+            console.error('Failed to send message on WebSocket:', error)
+          }
           logSubscriptionList.removeById(message.subscription_id)
 
           const socketSubscriptions = logSubscriptionList.getBySocket(socket as WebSocket.WebSocket)
@@ -81,13 +85,17 @@ export const setupEvmLogProviderConnectionStream = (): void => {
             socket?.close()
           }
         } else {
-          logSubscriptionList.getById(message.subscription_id)?.socket.send(
-            JSON.stringify({
-              jsonrpc: '2.0',
-              id: logSubscriptionList.requestIdBySubscriptionId.get(message.subscription_id),
-              result: false,
-            })
-          )
+          try {
+            logSubscriptionList.getById(message.subscription_id)?.socket.send(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                id: logSubscriptionList.requestIdBySubscriptionId.get(message.subscription_id),
+                result: false,
+              })
+            )
+          } catch (error) {
+            console.error('Failed to send message on WebSocket:', error)
+          }
         }
       }
       if (message.method == 'log_found') {


### PR DESCRIPTION
Linear: https://linear.app/shm/issue/SHARD-1185/improvements-on-top-of-shard-1058
Summary: Handle WebSocket send errors to prevent crashes on closed sockets