### PR TITLE
fix: ensure whitelisted IPs cannot be blacklisted

### DIFF
--- a/src/middlewares/rateLimit/RequestersList.ts
+++ b/src/middlewares/rateLimit/RequestersList.ts
@@ -61,6 +61,13 @@ export class RequestersList {
   }
 
   addToBlacklist(ip: string): void {
+    // Don't blacklist whitelisted IPs
+    if (this.whiteList.has(ip)) {
+      if (config.verbose) console.log(`IP ${ip} is whitelisted, cannot be blacklisted`)
+      return
+    }
+
+    // Don't add if already blacklisted
     if (this.bannedIps.some((record) => record.ip === ip)) {
       if (config.verbose) console.log(`IP ${ip} is already in the banned list`)
       return
@@ -220,6 +227,11 @@ export class RequestersList {
   }
 
   addHeavyRequest(ip: string): void {
+    // Skip tracking for whitelisted IPs
+    if (this.whiteList.has(ip)) {
+      return
+    }
+
     /*eslint-disable security/detect-object-injection */
     if (this.requestTracker[ip]) {
       this.requestTracker[ip].count += 1
@@ -378,8 +390,12 @@ export class RequestersList {
       return true
     }
 
-    // record this heavy request before checking
-    this.addHeavyRequest(ip)
+    // Don't track heavy requests for whitelisted IPs
+    if (!this.whiteList.has(ip)) {
+      // record this heavy request before checking
+      this.addHeavyRequest(ip)
+    }
+    
     const heavyReqHistory = this.heavyRequests.get(ip)
 
     if (heavyReqHistory && heavyReqHistory.length >= config.rateLimitOption.allowedHeavyRequestPerMin + 1) {

--- a/test/unit/middlewares/rateLimit.test.ts
+++ b/test/unit/middlewares/rateLimit.test.ts
@@ -278,6 +278,42 @@ describe('Rate Limiting', () => {
       
       expect(mockRes.status).toHaveBeenCalled()
     })
+
+    it('should not blacklist IPs that are whitelisted', async () => {
+      // Clean up the existing instance
+      requestersList.cleanUp()
+      
+      // Create a new instance with the whitelisted IP
+      const newRequestersList = new RequestersList([], [], ['127.0.0.1'])
+      
+      // Replace the global instance with our new one
+      Object.assign(requestersList, newRequestersList)
+
+      const mockReq = createMockRequest()
+      const mockRes = createMockResponse()
+      const mockNext = jest.fn()
+
+      // Try to trigger blacklisting by exceeding request limits
+      await makeParallelRequests(
+        DEFAULT_CONFIG.rateLimitOption.allowedHeavyRequestPerMin * 2,
+        mockReq,
+        mockRes,
+        mockNext
+      )
+
+      // Verify the IP was not blacklisted
+      expect(requestersList.isIpBanned('127.0.0.1')).toBe(false)
+      
+      // Verify next() was called instead of sending error response
+      expect(mockNext).toHaveBeenCalled()
+      expect(mockRes.status).not.toHaveBeenCalled()
+      expect(mockRes.send).not.toHaveBeenCalled()
+
+      // Verify IP was not written to blacklist file
+      const blacklistWrites = (fs.writeFileSync as jest.Mock).mock.calls
+        .filter(call => (call[0] as string).includes('blacklist.json'))
+      expect(blacklistWrites.length).toBe(0)
+    })
   })
 
   describe('Initialization', () => {


### PR DESCRIPTION
- Added whitelist check in addToBlacklist to prevent whitelisted IPs from being blacklisted

- Skip tracking heavy requests for whitelisted IPs in addHeavyRequest

- Added test to verify whitelisted IPs remain unblocked under heavy load

- Improved test setup to properly initialize RequestersList with whitelist