### PR TITLE
SHARD-1950 - fix: gas calculation returns non hex

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -220,7 +220,7 @@ function extractTransactionObject(
       from: tx.readableReceipt.from,
       gas:
         '0x' +
-        (hexStrToInt(tx.readableReceipt.gasUsed) + hexStrToInt(tx.readableReceipt.gasRefund)).toString(),
+        (hexToBN(tx.readableReceipt.gasUsed).add(hexToBN(tx.readableReceipt.gasRefund)).toString(16)),
       gasPrice: tx.readableReceipt.gasPrice,
       maxFeePerGas: undefined,
       maxPriorityFeePerGas: undefined,


### PR DESCRIPTION
I found this bug while fixing/testing SHARD-1947 locally where its trying to add integers then transform it back to a string but didnt put it into hex, so it was returning gas: "0x21000". i can reproduce locally but not on itn4 rpc url.

fixes: https://linear.app/shm/issue/SHARD-1950/gas-calculation-on-json-rpc-server-should-return-appropriate-hex-value