### PR TITLE
SHARD-2024: Fix incorrect transaction index

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -2403,7 +2403,10 @@ export const methods = {
       result = blockResp?.transactions[Number(args[1])]
       if (result) {
         if (typeof result === 'object' && result.transactionIndex && args[1] !== undefined) {
-          result.transactionIndex = '0x' + parseInt(args[1], 16).toString(16)
+          const transactionIndex = parseInt(args[1], 16);
+          if (!isNaN(transactionIndex)) {
+            result.transactionIndex = '0x' + transactionIndex.toString(16);
+          }
         }
         callback(null, result)
         countSuccessResponse(api_name, 'success', 'collector')
@@ -2483,7 +2486,10 @@ export const methods = {
       result = blockResp?.transactions[Number(args[1])]
       if (result) {
         if (typeof result === 'object' && result.transactionIndex && args[1] !== undefined) {
-          result.transactionIndex = '0x' + parseInt(args[1], 16).toString(16)
+          const transactionIndex = parseInt(args[1], 16);
+          if (!isNaN(transactionIndex)) {
+            result.transactionIndex = '0x' + transactionIndex.toString(16);
+          }
         }
         callback(null, result)
         countSuccessResponse(api_name, 'success', 'collector')

--- a/src/api.ts
+++ b/src/api.ts
@@ -2402,6 +2402,10 @@ export const methods = {
       const blockResp = await collectorAPI.getBlock(args[0], 'hash', true)
       result = blockResp?.transactions[Number(args[1])]
       if (result) {
+        // Fix the transactionIndex to match the requested index
+        if (typeof result === 'object' && result.transactionIndex) {
+          result.transactionIndex = '0x' + parseInt(args[1], 16).toString(16)
+        }
         callback(null, result)
         countSuccessResponse(api_name, 'success', 'collector')
         logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
@@ -2479,6 +2483,10 @@ export const methods = {
       const blockResp = await collectorAPI.getBlock(args[0], 'hex_num', true)
       result = blockResp?.transactions[Number(args[1])]
       if (result) {
+        // Fix the transactionIndex to match the requested index
+        if (typeof result === 'object' && result.transactionIndex) {
+          result.transactionIndex = '0x' + parseInt(args[1], 16).toString(16)
+        }
         callback(null, result)
         countSuccessResponse(api_name, 'success', 'collector')
         logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())

--- a/src/api.ts
+++ b/src/api.ts
@@ -51,6 +51,8 @@ import { nestedCountersInstance } from './utils/nestedCounters'
 import { trySpendServicePoints } from './utils/servicePoints'
 import { archiverAPI } from './external/Archiver'
 import { TTLMap } from './utils/TTLMap'
+import { buildGetTransactionByBlockHashAndIndex } from './eth-handlers/eth_getTransactionByBlockHashAndIndex'
+import { buildGetTransactionByBlockNumberAndIndex } from './eth-handlers/eth_getTransactionByBlockNumberAndIndex'
 
 export const verbose = config.verbose
 export const firstLineLogs = config.firstLineLogs
@@ -2381,174 +2383,32 @@ export const methods = {
     callback(null, result)
     countSuccessResponse(api_name, 'success', 'TBD')
   },
-  eth_getTransactionByBlockHashAndIndex: async function (args: RequestParamsLike, callback: JSONRPCCallbackTypePlain) {
-    const api_name = 'eth_getTransactionByBlockHashAndIndex'
-    nestedCountersInstance.countEvent('endpoint', api_name)
-    if (!ensureArrayArgs(args, callback)) {
-      countFailedResponse(api_name, 'Invalid params: non-array args')
-      return
-    }
-    const ticket = crypto
-      .createHash('sha1')
-      .update(api_name + Math.random() + Date.now())
-      .digest('hex')
-    logEventEmitter.emit('fn_start', ticket, api_name, performance.now())
-    /* prettier-ignore */ if (firstLineLogs) { console.log('Running eth_getTransactionByBlockHashAndIndex', args) }
-
-    logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
-    let result: string | completeReadableReceipt | null | undefined = null
-
-    try {
-      const blockResp = await collectorAPI.getBlock(args[0], 'hash', true)
-      result = blockResp?.transactions[Number(args[1])]
-      if (result) {
-        if (typeof result === 'object' && result.transactionIndex && args[1] !== undefined) {
-          const transactionIndex = parseInt(args[1], 16);
-          if (!isNaN(transactionIndex)) {
-            result.transactionIndex = '0x' + transactionIndex.toString(16);
-          }
-        }
-        callback(null, result)
-        countSuccessResponse(api_name, 'success', 'collector')
-        logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
-        return
-      }
-    } catch (e) {
-      callback(errorBusy)
-      countFailedResponse(api_name, 'exception in collectorAPI.getBlock')
-      logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
-    }
-    const blockHash = args[0]
-    const index = parseInt(args[1], 16)
-    //if (blockHash !== 'latest') blockHash = parseInt(blockHash, 16)
-    if (config.queryFromValidator && config.queryFromExplorer) {
-      const explorerUrl = config.explorerUrl
-      try {
-        const res = await axios.get(`${explorerUrl}/api/transaction?blockHash=${blockHash}`)
-        if (verbose) {
-          console.log('url', `${explorerUrl}/api/transaction?blockHash=${blockHash}`)
-          console.log('res', JSON.stringify(res.data))
-        }
-
-        let result
-        if (res.data.success) {
-          if (typeof index === 'number' && index >= 0 && index < res.data.transactions.length) {
-            // eslint-disable-next-line security/detect-object-injection
-            result = extractTransactionObject(res.data.transactions[index], index)
-          }
-        } else result = null
-
-        const nodeUrl = config.explorerUrl
-        if (verbose) console.log('TRANSACTION DETAIL', result)
-        callback(null, result)
-        countSuccessResponse(api_name, 'success', 'explorer')
-        logEventEmitter.emit(
-          'fn_end',
-          ticket,
-          { nodeUrl, success: res.data.transactions.length ? true : false },
-          performance.now()
-        )
-      } catch (error) {
-        /* prettier-ignore */ if (verbose) console.log('Error: eth_getTransactionByBlockHashAndIndex', (error as AxiosError).message)
-        callback(null, null)
-        countFailedResponse(api_name, 'exception in axios.get')
-        logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
-      }
-    } else {
-      console.log('queryFromValidator and/or queryFromExplorer turned off. Could not process request')
-      callback(null, null)
-      countFailedResponse(api_name, 'queryFromValidator and/or queryFromExplorer turned off')
-      logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
-    }
-    callback(null, result)
-    countSuccessResponse(api_name, 'success', 'fallback')
-    logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
-  },
-  eth_getTransactionByBlockNumberAndIndex: async function (
-    args: RequestParamsLike,
-    callback: JSONRPCCallbackTypePlain
-  ) {
-    const api_name = 'eth_getTransactionByBlockNumberAndIndex'
-    nestedCountersInstance.countEvent('endpoint', api_name)
-    if (!ensureArrayArgs(args, callback)) {
-      countFailedResponse(api_name, 'Invalid params: non-array args')
-      return
-    }
-    const ticket = crypto
-      .createHash('sha1')
-      .update(api_name + Math.random() + Date.now())
-      .digest('hex')
-    logEventEmitter.emit('fn_start', ticket, api_name, performance.now())
-
-    let result: string | completeReadableReceipt | null | undefined = null
-    try {
-      const blockResp = await collectorAPI.getBlock(args[0], 'hex_num', true)
-      result = blockResp?.transactions[Number(args[1])]
-      if (result) {
-        if (typeof result === 'object' && result.transactionIndex && args[1] !== undefined) {
-          const transactionIndex = parseInt(args[1], 16);
-          if (!isNaN(transactionIndex)) {
-            result.transactionIndex = '0x' + transactionIndex.toString(16);
-          }
-        }
-        callback(null, result)
-        countSuccessResponse(api_name, 'success', 'collector')
-        logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
-        return
-      }
-    } catch (e) {
-      callback(errorBusy)
-      countFailedResponse(api_name, 'exception in collectorAPI.getBlock')
-      logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
-    }
-    /* prettier-ignore */ if (firstLineLogs) { console.log('Running eth_getTransactionByBlockNumberAndIndex', args) }
-    let blockNumber = args[0]
-    const index = parseInt(args[1], 16)
-    if (blockNumber !== 'latest' && blockNumber !== 'earliest') blockNumber = parseInt(blockNumber, 16)
-    if (blockNumber === 'earliest') blockNumber = 0
-    if (config.queryFromExplorer) {
-      const explorerUrl = config.explorerUrl
-      try {
-        const res = await axios.get(`${explorerUrl}/api/transaction?blockNumber=${blockNumber}`)
-        if (verbose) {
-          console.log('url', `${explorerUrl}/api/transaction?blockNumber=${blockNumber}`)
-          console.log('res', JSON.stringify(res.data))
-        }
-
-        let result
-        if (res.data.success) {
-          if (typeof index === 'number' && index >= 0 && index < res.data.transactions.length) {
-            // eslint-disable-next-line security/detect-object-injection
-            result = extractTransactionObject(res.data.transactions[index], index)
-          }
-        } else result = null
-
-        const nodeUrl = config.explorerUrl
-        if (verbose) console.log('TRANSACTION DETAIL', result)
-        callback(null, result)
-        countSuccessResponse(api_name, 'success', 'explorer')
-        logEventEmitter.emit(
-          'fn_end',
-          ticket,
-          { nodeUrl, success: res.data.transactions.length ? true : false },
-          performance.now()
-        )
-      } catch (error) {
-        /* prettier-ignore */ if (verbose) console.log('Error: eth_getTransactionByBlockNumberAndIndex', (error as AxiosError).message)
-        callback(null, null)
-        countFailedResponse(api_name, 'exception in axios.get')
-        logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
-      }
-    } else {
-      console.log('queryFromExplorer turned off. Could not process request')
-      callback(null, null)
-      countFailedResponse(api_name, 'queryFromExplorer turned off')
-      logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
-    }
-    callback(null, result)
-    countSuccessResponse(api_name, 'success', 'fallback')
-    logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
-  },
+  eth_getTransactionByBlockHashAndIndex: buildGetTransactionByBlockHashAndIndex({
+    nestedCountersInstance,
+    ensureArrayArgs,
+    countFailedResponse,
+    logEventEmitter,
+    firstLineLogs,
+    collectorAPI,
+    extractTransactionObject,
+    countSuccessResponse,
+    config,
+    verbose,
+    errorBusy
+  }),
+  eth_getTransactionByBlockNumberAndIndex: buildGetTransactionByBlockNumberAndIndex({
+    nestedCountersInstance,
+    ensureArrayArgs,
+    countFailedResponse,
+    logEventEmitter,
+    firstLineLogs,
+    collectorAPI,
+    extractTransactionObject,
+    countSuccessResponse,
+    config,
+    verbose,
+    errorBusy
+  }),
   eth_getTransactionReceipt: async function (args: RequestParamsLike, callback: JSONRPCCallbackTypePlain) {
     const api_name = 'eth_getTransactionReceipt'
     nestedCountersInstance.countEvent('endpoint', api_name)

--- a/src/api.ts
+++ b/src/api.ts
@@ -2394,7 +2394,7 @@ export const methods = {
     countSuccessResponse,
     config,
     verbose,
-    errorBusy
+    errorBusy,
   }),
   eth_getTransactionByBlockNumberAndIndex: buildGetTransactionByBlockNumberAndIndex({
     nestedCountersInstance,
@@ -2407,7 +2407,7 @@ export const methods = {
     countSuccessResponse,
     config,
     verbose,
-    errorBusy
+    errorBusy,
   }),
   eth_getTransactionReceipt: async function (args: RequestParamsLike, callback: JSONRPCCallbackTypePlain) {
     const api_name = 'eth_getTransactionReceipt'

--- a/src/api.ts
+++ b/src/api.ts
@@ -2402,8 +2402,7 @@ export const methods = {
       const blockResp = await collectorAPI.getBlock(args[0], 'hash', true)
       result = blockResp?.transactions[Number(args[1])]
       if (result) {
-        // Fix the transactionIndex to match the requested index
-        if (typeof result === 'object' && result.transactionIndex) {
+        if (typeof result === 'object' && result.transactionIndex && args[1] !== undefined) {
           result.transactionIndex = '0x' + parseInt(args[1], 16).toString(16)
         }
         callback(null, result)
@@ -2483,8 +2482,7 @@ export const methods = {
       const blockResp = await collectorAPI.getBlock(args[0], 'hex_num', true)
       result = blockResp?.transactions[Number(args[1])]
       if (result) {
-        // Fix the transactionIndex to match the requested index
-        if (typeof result === 'object' && result.transactionIndex) {
+        if (typeof result === 'object' && result.transactionIndex && args[1] !== undefined) {
           result.transactionIndex = '0x' + parseInt(args[1], 16).toString(16)
         }
         callback(null, result)

--- a/src/eth-handlers/eth_getTransactionByBlockHashAndIndex.ts
+++ b/src/eth-handlers/eth_getTransactionByBlockHashAndIndex.ts
@@ -1,121 +1,118 @@
-import { JSONRPCCallbackTypePlain, RequestParamsLike } from "jayson"
-import crypto from "crypto"
-import { completeReadableReceipt } from "../external/Collector"
-import axios, { AxiosError } from "axios"
+import { JSONRPCCallbackTypePlain, RequestParamsLike } from 'jayson'
+import crypto from 'crypto'
+import { completeReadableReceipt } from '../external/Collector'
+import axios, { AxiosError } from 'axios'
 
 interface BuildGetTransactionByBlockHashAndIndex {
-    nestedCountersInstance: any,
-    ensureArrayArgs:any,
-    countFailedResponse:any,
-    logEventEmitter:any,
-    firstLineLogs:any,
-    collectorAPI:any,
-    extractTransactionObject:any,
-    countSuccessResponse:any,
-    config:any,
-    verbose:any,
-    errorBusy:any,
+  nestedCountersInstance: any
+  ensureArrayArgs: any
+  countFailedResponse: any
+  logEventEmitter: any
+  firstLineLogs: any
+  collectorAPI: any
+  extractTransactionObject: any
+  countSuccessResponse: any
+  config: any
+  verbose: any
+  errorBusy: any
 }
 
 export const buildGetTransactionByBlockHashAndIndex = ({
-    nestedCountersInstance, 
-    ensureArrayArgs, 
-    countFailedResponse, 
-    logEventEmitter, 
-    firstLineLogs, 
-    collectorAPI, 
-    extractTransactionObject, 
-    countSuccessResponse,
-    config,
-    verbose,
-    errorBusy
+  nestedCountersInstance,
+  ensureArrayArgs,
+  countFailedResponse,
+  logEventEmitter,
+  firstLineLogs,
+  collectorAPI,
+  extractTransactionObject,
+  countSuccessResponse,
+  config,
+  verbose,
+  errorBusy,
 }: BuildGetTransactionByBlockHashAndIndex) => {
+  const eth_getTransactionByBlockHashAndIndex = async (args: RequestParamsLike, callback: JSONRPCCallbackTypePlain) => {
+    const api_name = 'eth_getTransactionByBlockHashAndIndex'
+    nestedCountersInstance.countEvent('endpoint', api_name)
+    if (!ensureArrayArgs(args, callback)) {
+      countFailedResponse(api_name, 'Invalid params: non-array args')
+      return
+    }
+    const ticket = crypto
+      .createHash('sha1')
+      .update(api_name + Math.random() + Date.now())
+      .digest('hex')
+    logEventEmitter.emit('fn_start', ticket, api_name, performance.now())
+    /* prettier-ignore */ if (firstLineLogs) { console.log('Running eth_getTransactionByBlockHashAndIndex', args) }
 
-    const eth_getTransactionByBlockHashAndIndex = async (args: RequestParamsLike, callback: JSONRPCCallbackTypePlain) => {
-        const api_name = 'eth_getTransactionByBlockHashAndIndex'
-        nestedCountersInstance.countEvent('endpoint', api_name)
-        if (!ensureArrayArgs(args, callback)) {
-          countFailedResponse(api_name, 'Invalid params: non-array args')
-          return
-        }
-        const ticket = crypto
-          .createHash('sha1')
-          .update(api_name + Math.random() + Date.now())
-          .digest('hex')
-        logEventEmitter.emit('fn_start', ticket, api_name, performance.now())
-        /* prettier-ignore */ if (firstLineLogs) { console.log('Running eth_getTransactionByBlockHashAndIndex', args) }
-    
-        logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
-        let result: string | completeReadableReceipt | null | undefined = null
-    
-        try {
-          const blockResp = await collectorAPI.getBlock((args as any)[0], 'hash', true)
-          result = blockResp?.transactions[Number((args as any)[1])]
-          if (result) {
-            if (typeof result === 'object' && result.transactionIndex && (args as any)[1] !== undefined) {
-              const transactionIndex = parseInt((args as any)[1], 16);
-              if (!isNaN(transactionIndex)) {
-                result.transactionIndex = '0x' + transactionIndex.toString(16);
-              }
-            }
-            callback(null, result)
-            countSuccessResponse(api_name, 'success', 'collector')
-            logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
-            return
+    logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+    let result: string | completeReadableReceipt | null | undefined = null
+
+    try {
+      const blockResp = await collectorAPI.getBlock((args as any)[0], 'hash', true)
+      result = blockResp?.transactions[Number((args as any)[1])]
+      if (result) {
+        if (typeof result === 'object' && result.transactionIndex && (args as any)[1] !== undefined) {
+          const transactionIndex = parseInt((args as any)[1], 16)
+          if (!isNaN(transactionIndex)) {
+            result.transactionIndex = '0x' + transactionIndex.toString(16)
           }
-        } catch (e) {
-          callback(errorBusy)
-          countFailedResponse(api_name, 'exception in collectorAPI.getBlock')
-          logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
-        }
-        const blockHash = (args as any)[0]
-        const index = parseInt((args as any)[1], 16)
-        //if (blockHash !== 'latest') blockHash = parseInt(blockHash, 16)
-        if (config.queryFromValidator && config.queryFromExplorer) {
-          const explorerUrl = config.explorerUrl
-          try {
-            const res = await axios.get(`${explorerUrl}/api/transaction?blockHash=${blockHash}`)
-            if (verbose) {
-              console.log('url', `${explorerUrl}/api/transaction?blockHash=${blockHash}`)
-              console.log('res', JSON.stringify(res.data))
-            }
-    
-            let result
-            if (res.data.success) {
-              if (typeof index === 'number' && index >= 0 && index < res.data.transactions.length) {
-                // eslint-disable-next-line security/detect-object-injection
-                result = extractTransactionObject(res.data.transactions[index], index)
-              }
-            } else result = null
-    
-            const nodeUrl = config.explorerUrl
-            if (verbose) console.log('TRANSACTION DETAIL', result)
-            callback(null, result)
-            countSuccessResponse(api_name, 'success', 'explorer')
-            logEventEmitter.emit(
-              'fn_end',
-              ticket,
-              { nodeUrl, success: res.data.transactions.length ? true : false },
-              performance.now()
-            )
-          } catch (error) {
-            /* prettier-ignore */ if (verbose) console.log('Error: eth_getTransactionByBlockHashAndIndex', (error as AxiosError).message)
-            callback(null, null)
-            countFailedResponse(api_name, 'exception in axios.get')
-            logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
-          }
-        } else {
-          console.log('queryFromValidator and/or queryFromExplorer turned off. Could not process request')
-          callback(null, null)
-          countFailedResponse(api_name, 'queryFromValidator and/or queryFromExplorer turned off')
-          logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
         }
         callback(null, result)
-        countSuccessResponse(api_name, 'success', 'fallback')
+        countSuccessResponse(api_name, 'success', 'collector')
         logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
-      };
+        return
+      }
+    } catch (e) {
+      callback(errorBusy)
+      countFailedResponse(api_name, 'exception in collectorAPI.getBlock')
+      logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
+    }
+    const blockHash = (args as any)[0]
+    const index = parseInt((args as any)[1], 16)
+    //if (blockHash !== 'latest') blockHash = parseInt(blockHash, 16)
+    if (config.queryFromValidator && config.queryFromExplorer) {
+      const explorerUrl = config.explorerUrl
+      try {
+        const res = await axios.get(`${explorerUrl}/api/transaction?blockHash=${blockHash}`)
+        if (verbose) {
+          console.log('url', `${explorerUrl}/api/transaction?blockHash=${blockHash}`)
+          console.log('res', JSON.stringify(res.data))
+        }
 
-    return eth_getTransactionByBlockHashAndIndex
+        let result
+        if (res.data.success) {
+          if (typeof index === 'number' && index >= 0 && index < res.data.transactions.length) {
+            // eslint-disable-next-line security/detect-object-injection
+            result = extractTransactionObject(res.data.transactions[index], index)
+          }
+        } else result = null
+
+        const nodeUrl = config.explorerUrl
+        if (verbose) console.log('TRANSACTION DETAIL', result)
+        callback(null, result)
+        countSuccessResponse(api_name, 'success', 'explorer')
+        logEventEmitter.emit(
+          'fn_end',
+          ticket,
+          { nodeUrl, success: res.data.transactions.length ? true : false },
+          performance.now()
+        )
+      } catch (error) {
+        /* prettier-ignore */ if (verbose) console.log('Error: eth_getTransactionByBlockHashAndIndex', (error as AxiosError).message)
+        callback(null, null)
+        countFailedResponse(api_name, 'exception in axios.get')
+        logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
+      }
+    } else {
+      console.log('queryFromValidator and/or queryFromExplorer turned off. Could not process request')
+      callback(null, null)
+      countFailedResponse(api_name, 'queryFromValidator and/or queryFromExplorer turned off')
+      logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+    }
+    callback(null, result)
+    countSuccessResponse(api_name, 'success', 'fallback')
+    logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+  }
+
+  return eth_getTransactionByBlockHashAndIndex
 }
-
-

--- a/src/eth-handlers/eth_getTransactionByBlockHashAndIndex.ts
+++ b/src/eth-handlers/eth_getTransactionByBlockHashAndIndex.ts
@@ -1,0 +1,121 @@
+import { JSONRPCCallbackTypePlain, RequestParamsLike } from "jayson"
+import crypto from "crypto"
+import { completeReadableReceipt } from "../external/Collector"
+import axios, { AxiosError } from "axios"
+
+interface BuildGetTransactionByBlockHashAndIndex {
+    nestedCountersInstance: any,
+    ensureArrayArgs:any,
+    countFailedResponse:any,
+    logEventEmitter:any,
+    firstLineLogs:any,
+    collectorAPI:any,
+    extractTransactionObject:any,
+    countSuccessResponse:any,
+    config:any,
+    verbose:any,
+    errorBusy:any,
+}
+
+export const buildGetTransactionByBlockHashAndIndex = ({
+    nestedCountersInstance, 
+    ensureArrayArgs, 
+    countFailedResponse, 
+    logEventEmitter, 
+    firstLineLogs, 
+    collectorAPI, 
+    extractTransactionObject, 
+    countSuccessResponse,
+    config,
+    verbose,
+    errorBusy
+}: BuildGetTransactionByBlockHashAndIndex) => {
+
+    const eth_getTransactionByBlockHashAndIndex = async (args: RequestParamsLike, callback: JSONRPCCallbackTypePlain) => {
+        const api_name = 'eth_getTransactionByBlockHashAndIndex'
+        nestedCountersInstance.countEvent('endpoint', api_name)
+        if (!ensureArrayArgs(args, callback)) {
+          countFailedResponse(api_name, 'Invalid params: non-array args')
+          return
+        }
+        const ticket = crypto
+          .createHash('sha1')
+          .update(api_name + Math.random() + Date.now())
+          .digest('hex')
+        logEventEmitter.emit('fn_start', ticket, api_name, performance.now())
+        /* prettier-ignore */ if (firstLineLogs) { console.log('Running eth_getTransactionByBlockHashAndIndex', args) }
+    
+        logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+        let result: string | completeReadableReceipt | null | undefined = null
+    
+        try {
+          const blockResp = await collectorAPI.getBlock((args as any)[0], 'hash', true)
+          result = blockResp?.transactions[Number((args as any)[1])]
+          if (result) {
+            if (typeof result === 'object' && result.transactionIndex && (args as any)[1] !== undefined) {
+              const transactionIndex = parseInt((args as any)[1], 16);
+              if (!isNaN(transactionIndex)) {
+                result.transactionIndex = '0x' + transactionIndex.toString(16);
+              }
+            }
+            callback(null, result)
+            countSuccessResponse(api_name, 'success', 'collector')
+            logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+            return
+          }
+        } catch (e) {
+          callback(errorBusy)
+          countFailedResponse(api_name, 'exception in collectorAPI.getBlock')
+          logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
+        }
+        const blockHash = (args as any)[0]
+        const index = parseInt((args as any)[1], 16)
+        //if (blockHash !== 'latest') blockHash = parseInt(blockHash, 16)
+        if (config.queryFromValidator && config.queryFromExplorer) {
+          const explorerUrl = config.explorerUrl
+          try {
+            const res = await axios.get(`${explorerUrl}/api/transaction?blockHash=${blockHash}`)
+            if (verbose) {
+              console.log('url', `${explorerUrl}/api/transaction?blockHash=${blockHash}`)
+              console.log('res', JSON.stringify(res.data))
+            }
+    
+            let result
+            if (res.data.success) {
+              if (typeof index === 'number' && index >= 0 && index < res.data.transactions.length) {
+                // eslint-disable-next-line security/detect-object-injection
+                result = extractTransactionObject(res.data.transactions[index], index)
+              }
+            } else result = null
+    
+            const nodeUrl = config.explorerUrl
+            if (verbose) console.log('TRANSACTION DETAIL', result)
+            callback(null, result)
+            countSuccessResponse(api_name, 'success', 'explorer')
+            logEventEmitter.emit(
+              'fn_end',
+              ticket,
+              { nodeUrl, success: res.data.transactions.length ? true : false },
+              performance.now()
+            )
+          } catch (error) {
+            /* prettier-ignore */ if (verbose) console.log('Error: eth_getTransactionByBlockHashAndIndex', (error as AxiosError).message)
+            callback(null, null)
+            countFailedResponse(api_name, 'exception in axios.get')
+            logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
+          }
+        } else {
+          console.log('queryFromValidator and/or queryFromExplorer turned off. Could not process request')
+          callback(null, null)
+          countFailedResponse(api_name, 'queryFromValidator and/or queryFromExplorer turned off')
+          logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+        }
+        callback(null, result)
+        countSuccessResponse(api_name, 'success', 'fallback')
+        logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+      };
+
+    return eth_getTransactionByBlockHashAndIndex
+}
+
+

--- a/src/eth-handlers/eth_getTransactionByBlockHashAndIndex.ts
+++ b/src/eth-handlers/eth_getTransactionByBlockHashAndIndex.ts
@@ -29,8 +29,14 @@ export const buildGetTransactionByBlockHashAndIndex = ({
   config,
   verbose,
   errorBusy,
-}: BuildGetTransactionByBlockHashAndIndex) => {
-  const eth_getTransactionByBlockHashAndIndex = async (args: RequestParamsLike, callback: JSONRPCCallbackTypePlain) => {
+}: BuildGetTransactionByBlockHashAndIndex): ((
+  args: RequestParamsLike,
+  callback: JSONRPCCallbackTypePlain
+) => Promise<void>) => {
+  const eth_getTransactionByBlockHashAndIndex = async (
+    args: RequestParamsLike,
+    callback: JSONRPCCallbackTypePlain
+  ): Promise<void> => {
     const api_name = 'eth_getTransactionByBlockHashAndIndex'
     nestedCountersInstance.countEvent('endpoint', api_name)
     if (!ensureArrayArgs(args, callback)) {

--- a/src/eth-handlers/eth_getTransactionByBlockNumberAndIndex.ts
+++ b/src/eth-handlers/eth_getTransactionByBlockNumberAndIndex.ts
@@ -31,11 +31,14 @@ export const buildGetTransactionByBlockNumberAndIndex = ({
   config,
   verbose,
   errorBusy,
-}: BuildGetTransactionByBlockNumberAndIndex) => {
+}: BuildGetTransactionByBlockNumberAndIndex): ((
+  args: RequestParamsLike,
+  callback: JSONRPCCallbackTypePlain
+) => Promise<void>) => {
   const eth_getTransactionByBlockNumberAndIndex = async (
     args: RequestParamsLike,
     callback: JSONRPCCallbackTypePlain
-  ) => {
+  ): Promise<void> => {
     const api_name = 'eth_getTransactionByBlockNumberAndIndex'
     nestedCountersInstance.countEvent('endpoint', api_name)
     if (!ensureArrayArgs(args, callback)) {

--- a/src/eth-handlers/eth_getTransactionByBlockNumberAndIndex.ts
+++ b/src/eth-handlers/eth_getTransactionByBlockNumberAndIndex.ts
@@ -1,120 +1,122 @@
-import { AxiosError } from "axios"
-import { RequestParamsLike } from "jayson"
-import crypto from "crypto"
-import { completeReadableReceipt } from "../external/Collector";
-import { JSONRPCCallbackTypePlain } from "jayson";
-import axios from "axios";
+import { AxiosError } from 'axios'
+import { RequestParamsLike } from 'jayson'
+import crypto from 'crypto'
+import { completeReadableReceipt } from '../external/Collector'
+import { JSONRPCCallbackTypePlain } from 'jayson'
+import axios from 'axios'
 
 interface BuildGetTransactionByBlockNumberAndIndex {
-    nestedCountersInstance: any,
-    ensureArrayArgs:any,
-    countFailedResponse:any,
-    logEventEmitter:any,
-    firstLineLogs:any,
-    collectorAPI:any,
-    extractTransactionObject:any,
-    countSuccessResponse:any,
-    config:any,
-    verbose:any,
-    errorBusy:any,
+  nestedCountersInstance: any
+  ensureArrayArgs: any
+  countFailedResponse: any
+  logEventEmitter: any
+  firstLineLogs: any
+  collectorAPI: any
+  extractTransactionObject: any
+  countSuccessResponse: any
+  config: any
+  verbose: any
+  errorBusy: any
 }
 
 export const buildGetTransactionByBlockNumberAndIndex = ({
-    nestedCountersInstance,
-    ensureArrayArgs,
-    countFailedResponse,
-    logEventEmitter,
-    firstLineLogs,
-    collectorAPI,
-    extractTransactionObject,
-    countSuccessResponse,
-    config,
-    verbose,
-    errorBusy
+  nestedCountersInstance,
+  ensureArrayArgs,
+  countFailedResponse,
+  logEventEmitter,
+  firstLineLogs,
+  collectorAPI,
+  extractTransactionObject,
+  countSuccessResponse,
+  config,
+  verbose,
+  errorBusy,
 }: BuildGetTransactionByBlockNumberAndIndex) => {
+  const eth_getTransactionByBlockNumberAndIndex = async (
+    args: RequestParamsLike,
+    callback: JSONRPCCallbackTypePlain
+  ) => {
+    const api_name = 'eth_getTransactionByBlockNumberAndIndex'
+    nestedCountersInstance.countEvent('endpoint', api_name)
+    if (!ensureArrayArgs(args, callback)) {
+      countFailedResponse(api_name, 'Invalid params: non-array args')
+      return
+    }
+    const ticket = crypto
+      .createHash('sha1')
+      .update(api_name + Math.random() + Date.now())
+      .digest('hex')
+    logEventEmitter.emit('fn_start', ticket, api_name, performance.now())
 
-    const eth_getTransactionByBlockNumberAndIndex = async (args: RequestParamsLike, callback: JSONRPCCallbackTypePlain) => {
-        const api_name = 'eth_getTransactionByBlockNumberAndIndex'
-        nestedCountersInstance.countEvent('endpoint', api_name)
-        if (!ensureArrayArgs(args, callback)) {
-          countFailedResponse(api_name, 'Invalid params: non-array args')
-          return
-        }
-        const ticket = crypto
-          .createHash('sha1')
-          .update(api_name + Math.random() + Date.now())
-          .digest('hex')
-        logEventEmitter.emit('fn_start', ticket, api_name, performance.now())
-    
-        let result: string | completeReadableReceipt | null | undefined = null
-        try {
-          const blockResp = await collectorAPI.getBlock((args as any)[0], 'hex_num', true)
-          result = blockResp?.transactions[Number((args as any)[1])]
-          if (result) {
-            if (typeof result === 'object' && result.transactionIndex && (args as any)[1] !== undefined) {
-              const transactionIndex = parseInt((args as any)[1], 16);
-              if (!isNaN(transactionIndex)) {
-                result.transactionIndex = '0x' + transactionIndex.toString(16);
-              }
-            }
-            callback(null, result)
-            countSuccessResponse(api_name, 'success', 'collector')
-            logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
-            return
+    let result: string | completeReadableReceipt | null | undefined = null
+    try {
+      const blockResp = await collectorAPI.getBlock((args as any)[0], 'hex_num', true)
+      result = blockResp?.transactions[Number((args as any)[1])]
+      if (result) {
+        if (typeof result === 'object' && result.transactionIndex && (args as any)[1] !== undefined) {
+          const transactionIndex = parseInt((args as any)[1], 16)
+          if (!isNaN(transactionIndex)) {
+            result.transactionIndex = '0x' + transactionIndex.toString(16)
           }
-        } catch (e) {
-          callback(errorBusy)
-          countFailedResponse(api_name, 'exception in collectorAPI.getBlock')
-          logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
-        }
-        /* prettier-ignore */ if (firstLineLogs) { console.log('Running eth_getTransactionByBlockNumberAndIndex', args) }
-        let blockNumber = (args as any)[0]
-        const index = parseInt((args as any)[1], 16)
-        if (blockNumber !== 'latest' && blockNumber !== 'earliest') blockNumber = parseInt(blockNumber, 16)
-        if (blockNumber === 'earliest') blockNumber = 0
-        if (config.queryFromExplorer) {
-          const explorerUrl = config.explorerUrl
-          try {
-            const res = await axios.get(`${explorerUrl}/api/transaction?blockNumber=${blockNumber}`)
-            if (verbose) {
-              console.log('url', `${explorerUrl}/api/transaction?blockNumber=${blockNumber}`)
-              console.log('res', JSON.stringify(res.data))
-            }
-    
-            let result
-            if (res.data.success) {
-              if (typeof index === 'number' && index >= 0 && index < res.data.transactions.length) {
-                // eslint-disable-next-line security/detect-object-injection
-                result = extractTransactionObject(res.data.transactions[index], index)
-              }
-            } else result = null
-    
-            const nodeUrl = config.explorerUrl
-            if (verbose) console.log('TRANSACTION DETAIL', result)
-            callback(null, result)
-            countSuccessResponse(api_name, 'success', 'explorer')
-            logEventEmitter.emit(
-              'fn_end',
-              ticket,
-              { nodeUrl, success: res.data.transactions.length ? true : false },
-              performance.now()
-            )
-          } catch (error) {
-            /* prettier-ignore */ if (verbose) console.log('Error: eth_getTransactionByBlockNumberAndIndex', (error as AxiosError).message)
-            callback(null, null)
-            countFailedResponse(api_name, 'exception in axios.get')
-            logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
-          }
-        } else {
-          console.log('queryFromExplorer turned off. Could not process request')
-          callback(null, null)
-          countFailedResponse(api_name, 'queryFromExplorer turned off')
-          logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
         }
         callback(null, result)
-        countSuccessResponse(api_name, 'success', 'fallback')
+        countSuccessResponse(api_name, 'success', 'collector')
         logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
-    };
+        return
+      }
+    } catch (e) {
+      callback(errorBusy)
+      countFailedResponse(api_name, 'exception in collectorAPI.getBlock')
+      logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
+    }
+    /* prettier-ignore */ if (firstLineLogs) { console.log('Running eth_getTransactionByBlockNumberAndIndex', args) }
+    let blockNumber = (args as any)[0]
+    const index = parseInt((args as any)[1], 16)
+    if (blockNumber !== 'latest' && blockNumber !== 'earliest') blockNumber = parseInt(blockNumber, 16)
+    if (blockNumber === 'earliest') blockNumber = 0
+    if (config.queryFromExplorer) {
+      const explorerUrl = config.explorerUrl
+      try {
+        const res = await axios.get(`${explorerUrl}/api/transaction?blockNumber=${blockNumber}`)
+        if (verbose) {
+          console.log('url', `${explorerUrl}/api/transaction?blockNumber=${blockNumber}`)
+          console.log('res', JSON.stringify(res.data))
+        }
 
-    return eth_getTransactionByBlockNumberAndIndex;
+        let result
+        if (res.data.success) {
+          if (typeof index === 'number' && index >= 0 && index < res.data.transactions.length) {
+            // eslint-disable-next-line security/detect-object-injection
+            result = extractTransactionObject(res.data.transactions[index], index)
+          }
+        } else result = null
+
+        const nodeUrl = config.explorerUrl
+        if (verbose) console.log('TRANSACTION DETAIL', result)
+        callback(null, result)
+        countSuccessResponse(api_name, 'success', 'explorer')
+        logEventEmitter.emit(
+          'fn_end',
+          ticket,
+          { nodeUrl, success: res.data.transactions.length ? true : false },
+          performance.now()
+        )
+      } catch (error) {
+        /* prettier-ignore */ if (verbose) console.log('Error: eth_getTransactionByBlockNumberAndIndex', (error as AxiosError).message)
+        callback(null, null)
+        countFailedResponse(api_name, 'exception in axios.get')
+        logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
+      }
+    } else {
+      console.log('queryFromExplorer turned off. Could not process request')
+      callback(null, null)
+      countFailedResponse(api_name, 'queryFromExplorer turned off')
+      logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+    }
+    callback(null, result)
+    countSuccessResponse(api_name, 'success', 'fallback')
+    logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+  }
+
+  return eth_getTransactionByBlockNumberAndIndex
 }

--- a/src/eth-handlers/eth_getTransactionByBlockNumberAndIndex.ts
+++ b/src/eth-handlers/eth_getTransactionByBlockNumberAndIndex.ts
@@ -1,0 +1,120 @@
+import { AxiosError } from "axios"
+import { RequestParamsLike } from "jayson"
+import crypto from "crypto"
+import { completeReadableReceipt } from "../external/Collector";
+import { JSONRPCCallbackTypePlain } from "jayson";
+import axios from "axios";
+
+interface BuildGetTransactionByBlockNumberAndIndex {
+    nestedCountersInstance: any,
+    ensureArrayArgs:any,
+    countFailedResponse:any,
+    logEventEmitter:any,
+    firstLineLogs:any,
+    collectorAPI:any,
+    extractTransactionObject:any,
+    countSuccessResponse:any,
+    config:any,
+    verbose:any,
+    errorBusy:any,
+}
+
+export const buildGetTransactionByBlockNumberAndIndex = ({
+    nestedCountersInstance,
+    ensureArrayArgs,
+    countFailedResponse,
+    logEventEmitter,
+    firstLineLogs,
+    collectorAPI,
+    extractTransactionObject,
+    countSuccessResponse,
+    config,
+    verbose,
+    errorBusy
+}: BuildGetTransactionByBlockNumberAndIndex) => {
+
+    const eth_getTransactionByBlockNumberAndIndex = async (args: RequestParamsLike, callback: JSONRPCCallbackTypePlain) => {
+        const api_name = 'eth_getTransactionByBlockNumberAndIndex'
+        nestedCountersInstance.countEvent('endpoint', api_name)
+        if (!ensureArrayArgs(args, callback)) {
+          countFailedResponse(api_name, 'Invalid params: non-array args')
+          return
+        }
+        const ticket = crypto
+          .createHash('sha1')
+          .update(api_name + Math.random() + Date.now())
+          .digest('hex')
+        logEventEmitter.emit('fn_start', ticket, api_name, performance.now())
+    
+        let result: string | completeReadableReceipt | null | undefined = null
+        try {
+          const blockResp = await collectorAPI.getBlock((args as any)[0], 'hex_num', true)
+          result = blockResp?.transactions[Number((args as any)[1])]
+          if (result) {
+            if (typeof result === 'object' && result.transactionIndex && (args as any)[1] !== undefined) {
+              const transactionIndex = parseInt((args as any)[1], 16);
+              if (!isNaN(transactionIndex)) {
+                result.transactionIndex = '0x' + transactionIndex.toString(16);
+              }
+            }
+            callback(null, result)
+            countSuccessResponse(api_name, 'success', 'collector')
+            logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+            return
+          }
+        } catch (e) {
+          callback(errorBusy)
+          countFailedResponse(api_name, 'exception in collectorAPI.getBlock')
+          logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
+        }
+        /* prettier-ignore */ if (firstLineLogs) { console.log('Running eth_getTransactionByBlockNumberAndIndex', args) }
+        let blockNumber = (args as any)[0]
+        const index = parseInt((args as any)[1], 16)
+        if (blockNumber !== 'latest' && blockNumber !== 'earliest') blockNumber = parseInt(blockNumber, 16)
+        if (blockNumber === 'earliest') blockNumber = 0
+        if (config.queryFromExplorer) {
+          const explorerUrl = config.explorerUrl
+          try {
+            const res = await axios.get(`${explorerUrl}/api/transaction?blockNumber=${blockNumber}`)
+            if (verbose) {
+              console.log('url', `${explorerUrl}/api/transaction?blockNumber=${blockNumber}`)
+              console.log('res', JSON.stringify(res.data))
+            }
+    
+            let result
+            if (res.data.success) {
+              if (typeof index === 'number' && index >= 0 && index < res.data.transactions.length) {
+                // eslint-disable-next-line security/detect-object-injection
+                result = extractTransactionObject(res.data.transactions[index], index)
+              }
+            } else result = null
+    
+            const nodeUrl = config.explorerUrl
+            if (verbose) console.log('TRANSACTION DETAIL', result)
+            callback(null, result)
+            countSuccessResponse(api_name, 'success', 'explorer')
+            logEventEmitter.emit(
+              'fn_end',
+              ticket,
+              { nodeUrl, success: res.data.transactions.length ? true : false },
+              performance.now()
+            )
+          } catch (error) {
+            /* prettier-ignore */ if (verbose) console.log('Error: eth_getTransactionByBlockNumberAndIndex', (error as AxiosError).message)
+            callback(null, null)
+            countFailedResponse(api_name, 'exception in axios.get')
+            logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
+          }
+        } else {
+          console.log('queryFromExplorer turned off. Could not process request')
+          callback(null, null)
+          countFailedResponse(api_name, 'queryFromExplorer turned off')
+          logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+        }
+        callback(null, result)
+        countSuccessResponse(api_name, 'success', 'fallback')
+        logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+    };
+
+    return eth_getTransactionByBlockNumberAndIndex;
+}

--- a/test/unit/eth-handlers/eth_getTransactionByBlockHashAndIndex.test.ts
+++ b/test/unit/eth-handlers/eth_getTransactionByBlockHashAndIndex.test.ts
@@ -1,0 +1,308 @@
+import { buildGetTransactionByBlockHashAndIndex } from '../../../src/eth-handlers/eth_getTransactionByBlockHashAndIndex';
+import axios from 'axios';
+import { completeReadableReceipt } from '../../../src/external/Collector';
+import { RequestParamsLike } from 'jayson';
+
+// Mock dependencies
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Mock crypto for the ticket generation
+jest.mock('crypto', () => ({
+  createHash: jest.fn().mockReturnValue({
+    update: jest.fn().mockReturnValue({
+      digest: jest.fn().mockReturnValue('test-ticket-hash'),
+    }),
+  }),
+}));
+
+describe('eth_getTransactionByBlockHashAndIndex handler', () => {
+  // Common test values
+  const blockHash = '0x1234567890abcdef';
+  const txIndex = '0x1';
+  
+  // Declare mocks
+  let mockNestedCountersInstance: any;
+  let mockEnsureArrayArgs: jest.Mock;
+  let mockCountFailedResponse: jest.Mock;
+  let mockLogEventEmitter: any;
+  let mockCollectorAPI: any;
+  let mockExtractTransactionObject: jest.Mock;
+  let mockCountSuccessResponse: jest.Mock;
+  let mockConfig: any;
+  let mockCallback: jest.Mock;
+  let eth_getTransactionByBlockHashAndIndex: any;
+
+  // Initialize all mocks before each test
+  beforeEach(() => {
+    // Create fresh mocks for all dependencies
+    mockNestedCountersInstance = {
+      countEvent: jest.fn(),
+    };
+    mockEnsureArrayArgs = jest.fn();
+    mockCountFailedResponse = jest.fn();
+    mockLogEventEmitter = {
+      emit: jest.fn(),
+    };
+    mockCollectorAPI = {
+      getBlock: jest.fn(),
+    };
+    mockExtractTransactionObject = jest.fn();
+    mockCountSuccessResponse = jest.fn();
+    mockConfig = {
+      queryFromValidator: true,
+      queryFromExplorer: true,
+      explorerUrl: 'https://explorer.example.com'
+    };
+    mockCallback = jest.fn();
+
+    // Reset axios mock
+    mockedAxios.get.mockReset();
+
+    // Build the handler function with fresh mocks
+    eth_getTransactionByBlockHashAndIndex = buildGetTransactionByBlockHashAndIndex({
+      nestedCountersInstance: mockNestedCountersInstance,
+      ensureArrayArgs: mockEnsureArrayArgs,
+      countFailedResponse: mockCountFailedResponse,
+      logEventEmitter: mockLogEventEmitter,
+      firstLineLogs: false,
+      collectorAPI: mockCollectorAPI,
+      extractTransactionObject: mockExtractTransactionObject,
+      countSuccessResponse: mockCountSuccessResponse,
+      config: mockConfig,
+      verbose: false,
+      errorBusy: { code: -32005, message: 'Server busy' },
+    });
+  });
+
+  describe('Input validation', () => {
+    beforeEach(() => {
+      // Setup ensureArrayArgs to return false for this specific test group
+      mockEnsureArrayArgs.mockReturnValue(false);
+    });
+
+    it('should reject non-array arguments', async () => {
+      // Call the function with non-array args
+      await eth_getTransactionByBlockHashAndIndex({ invalid: true } as RequestParamsLike, mockCallback);
+      
+      // Verify behavior
+      expect(mockNestedCountersInstance.countEvent).toHaveBeenCalledWith('endpoint', 'eth_getTransactionByBlockHashAndIndex');
+      expect(mockEnsureArrayArgs).toHaveBeenCalledWith({ invalid: true }, mockCallback);
+      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockHashAndIndex', 'Invalid params: non-array args');
+      expect(mockCallback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Collector API path', () => {
+    beforeEach(() => {
+      // Setup ensureArrayArgs to return true for this test group
+      mockEnsureArrayArgs.mockReturnValue(true);
+    });
+
+    it('should return transaction from collector when available', async () => {
+      const mockTransaction: Partial<completeReadableReceipt> = {
+        blockHash: blockHash,
+        transactionIndex: '0x1',
+      };
+      
+      // Mock the collectorAPI.getBlock response
+      mockCollectorAPI.getBlock.mockResolvedValue({
+        transactions: [mockTransaction, mockTransaction]
+      });
+      
+      // Call the function
+      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback);
+      
+      // Verify behavior
+      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockHash, 'hash', true);
+      expect(mockCallback).toHaveBeenCalledWith(null, mockTransaction);
+      expect(mockCountSuccessResponse).toHaveBeenCalledWith('eth_getTransactionByBlockHashAndIndex', 'success', 'collector');
+    });
+
+    it('should adjust transactionIndex to match the input index', async () => {
+      const mockTransaction: Partial<completeReadableReceipt> = {
+        blockHash: blockHash,
+        transactionIndex: '0x0', // Intentionally different from input index
+      };
+      
+      // Mock the collectorAPI.getBlock response
+      mockCollectorAPI.getBlock.mockResolvedValue({
+        transactions: [mockTransaction, mockTransaction]
+      });
+      
+      // Call the function
+      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback);
+      
+      // Verify behavior
+      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockHash, 'hash', true);
+      // The transaction object should be returned with transactionIndex adjusted
+      expect(mockCallback).toHaveBeenCalledWith(null, {
+        ...mockTransaction,
+        transactionIndex: '0x1' // Should match the input index
+      });
+    });
+
+    it('should handle exception from collector API', async () => {
+      // Mock the collectorAPI.getBlock to throw an error
+      mockCollectorAPI.getBlock.mockRejectedValue(new Error('Collector API error'));
+      
+      // Call the function
+      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback);
+      
+      // Verify behavior
+      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockHash, 'hash', true);
+      expect(mockCallback).toHaveBeenCalledWith({ code: -32005, message: 'Server busy' });
+      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockHashAndIndex', 'exception in collectorAPI.getBlock');
+    });
+  });
+
+  describe('Explorer API path', () => {
+    beforeEach(() => {
+      // Setup ensureArrayArgs to return true for this test group
+      mockEnsureArrayArgs.mockReturnValue(true);
+      
+      // Setup collector API to return empty results for the Explorer path tests
+      mockCollectorAPI.getBlock.mockResolvedValue({
+        transactions: []
+      });
+    });
+
+    it('should fetch transaction from explorer when collector API has no result', async () => {
+      // Setup mock explorer response
+      const mockExplorerResponse = {
+        data: {
+          success: true,
+          transactions: [
+            { id: 'tx1' },
+            { id: 'tx2' }
+          ]
+        }
+      };
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
+      
+      // Setup extractTransactionObject to return a mock transaction
+      const mockExtractedTx = { hash: '0xabc', blockHash };
+      mockExtractTransactionObject.mockReturnValue(mockExtractedTx);
+      
+      // Call the function
+      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback);
+      
+      // Verify behavior
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockHash=${blockHash}`);
+      expect(mockExtractTransactionObject).toHaveBeenCalledWith(mockExplorerResponse.data.transactions[1], 1);
+      expect(mockCallback).toHaveBeenCalledWith(null, mockExtractedTx);
+      expect(mockCountSuccessResponse).toHaveBeenCalledWith('eth_getTransactionByBlockHashAndIndex', 'success', 'explorer');
+    });
+
+    it('should handle explorer API errors', async () => {
+      // Setup mock explorer to throw an error
+      mockedAxios.get.mockRejectedValue(new Error('Explorer API error'));
+      
+      // Call the function
+      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback);
+      
+      // Verify behavior
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockHash=${blockHash}`);
+      expect(mockCallback).toHaveBeenCalledWith(null, null);
+      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockHashAndIndex', 'exception in axios.get');
+    });
+
+    it('should handle invalid index gracefully', async () => {
+      const outOfBoundsIndex = '0x5'; // Index that's out of bounds
+      
+      // Setup mock explorer response with fewer transactions than the index
+      const mockExplorerResponse = {
+        data: {
+          success: true,
+          transactions: [
+            { id: 'tx1' },
+            { id: 'tx2' }
+          ]
+        }
+      };
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
+      
+      // Call the function
+      await eth_getTransactionByBlockHashAndIndex([blockHash, outOfBoundsIndex], mockCallback);
+      
+      // Verify behavior
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockHash=${blockHash}`);
+      // extractTransactionObject shouldn't be called since index is invalid
+      expect(mockExtractTransactionObject).not.toHaveBeenCalled();
+      
+      // The implementation calls callback twice:
+      // First in the explorer path with null (no result)
+      expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined);
+      // Then again at the end of the function with the original result variable (still undefined)
+      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined);
+      expect(mockCallback).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle explorer unsuccessful response', async () => {
+      // Setup mock explorer response with success: false
+      const mockExplorerResponse = {
+        data: {
+          success: false,
+          transactions: []
+        }
+      };
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
+      
+      // Call the function
+      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback);
+      
+      // Verify behavior
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockHash=${blockHash}`);
+      
+      // The implementation calls callback twice:
+      // First in the explorer path with null (unsuccessful response)
+      expect(mockCallback).toHaveBeenNthCalledWith(1, null, null);
+      // Then again at the end of the function with the original result variable (undefined in the refactored test)
+      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined);
+      expect(mockCallback).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Configuration state handling', () => {
+    beforeEach(() => {
+      // Setup ensureArrayArgs to return true for this test group
+      mockEnsureArrayArgs.mockReturnValue(true);
+      
+      // Setup collector API to return null
+      mockCollectorAPI.getBlock.mockResolvedValue({
+        transactions: []
+      });
+    });
+
+    it('should handle disabled queryFromValidator and queryFromExplorer', async () => {
+      // Disable both config options
+      const disabledConfig = {
+        ...mockConfig,
+        queryFromValidator: false,
+        queryFromExplorer: false
+      };
+      
+      // Rebuild handler with disabled config
+      const handlerWithDisabledConfig = buildGetTransactionByBlockHashAndIndex({
+        nestedCountersInstance: mockNestedCountersInstance,
+        ensureArrayArgs: mockEnsureArrayArgs,
+        countFailedResponse: mockCountFailedResponse,
+        logEventEmitter: mockLogEventEmitter,
+        firstLineLogs: false,
+        collectorAPI: mockCollectorAPI,
+        extractTransactionObject: mockExtractTransactionObject,
+        countSuccessResponse: mockCountSuccessResponse,
+        config: disabledConfig,
+        verbose: false,
+        errorBusy: { code: -32005, message: 'Server busy' },
+      });
+      
+      // Call the function
+      await handlerWithDisabledConfig([blockHash, txIndex], mockCallback);
+      
+      // Verify behavior
+      expect(mockCallback).toHaveBeenCalledWith(null, null);
+      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockHashAndIndex', 'queryFromValidator and/or queryFromExplorer turned off');
+    });
+  });
+}); 

--- a/test/unit/eth-handlers/eth_getTransactionByBlockHashAndIndex.test.ts
+++ b/test/unit/eth-handlers/eth_getTransactionByBlockHashAndIndex.test.ts
@@ -1,11 +1,11 @@
-import { buildGetTransactionByBlockHashAndIndex } from '../../../src/eth-handlers/eth_getTransactionByBlockHashAndIndex';
-import axios from 'axios';
-import { completeReadableReceipt } from '../../../src/external/Collector';
-import { RequestParamsLike } from 'jayson';
+import { buildGetTransactionByBlockHashAndIndex } from '../../../src/eth-handlers/eth_getTransactionByBlockHashAndIndex'
+import axios from 'axios'
+import { completeReadableReceipt } from '../../../src/external/Collector'
+import { RequestParamsLike } from 'jayson'
 
 // Mock dependencies
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>
 
 // Mock crypto for the ticket generation
 jest.mock('crypto', () => ({
@@ -14,50 +14,50 @@ jest.mock('crypto', () => ({
       digest: jest.fn().mockReturnValue('test-ticket-hash'),
     }),
   }),
-}));
+}))
 
 describe('eth_getTransactionByBlockHashAndIndex handler', () => {
   // Common test values
-  const blockHash = '0x1234567890abcdef';
-  const txIndex = '0x1';
-  
+  const blockHash = '0x1234567890abcdef'
+  const txIndex = '0x1'
+
   // Declare mocks
-  let mockNestedCountersInstance: any;
-  let mockEnsureArrayArgs: jest.Mock;
-  let mockCountFailedResponse: jest.Mock;
-  let mockLogEventEmitter: any;
-  let mockCollectorAPI: any;
-  let mockExtractTransactionObject: jest.Mock;
-  let mockCountSuccessResponse: jest.Mock;
-  let mockConfig: any;
-  let mockCallback: jest.Mock;
-  let eth_getTransactionByBlockHashAndIndex: any;
+  let mockNestedCountersInstance: any
+  let mockEnsureArrayArgs: jest.Mock
+  let mockCountFailedResponse: jest.Mock
+  let mockLogEventEmitter: any
+  let mockCollectorAPI: any
+  let mockExtractTransactionObject: jest.Mock
+  let mockCountSuccessResponse: jest.Mock
+  let mockConfig: any
+  let mockCallback: jest.Mock
+  let eth_getTransactionByBlockHashAndIndex: any
 
   // Initialize all mocks before each test
   beforeEach(() => {
     // Create fresh mocks for all dependencies
     mockNestedCountersInstance = {
       countEvent: jest.fn(),
-    };
-    mockEnsureArrayArgs = jest.fn();
-    mockCountFailedResponse = jest.fn();
+    }
+    mockEnsureArrayArgs = jest.fn()
+    mockCountFailedResponse = jest.fn()
     mockLogEventEmitter = {
       emit: jest.fn(),
-    };
+    }
     mockCollectorAPI = {
       getBlock: jest.fn(),
-    };
-    mockExtractTransactionObject = jest.fn();
-    mockCountSuccessResponse = jest.fn();
+    }
+    mockExtractTransactionObject = jest.fn()
+    mockCountSuccessResponse = jest.fn()
     mockConfig = {
       queryFromValidator: true,
       queryFromExplorer: true,
-      explorerUrl: 'https://explorer.example.com'
-    };
-    mockCallback = jest.fn();
+      explorerUrl: 'https://explorer.example.com',
+    }
+    mockCallback = jest.fn()
 
     // Reset axios mock
-    mockedAxios.get.mockReset();
+    mockedAxios.get.mockReset()
 
     // Build the handler function with fresh mocks
     eth_getTransactionByBlockHashAndIndex = buildGetTransactionByBlockHashAndIndex({
@@ -72,216 +72,230 @@ describe('eth_getTransactionByBlockHashAndIndex handler', () => {
       config: mockConfig,
       verbose: false,
       errorBusy: { code: -32005, message: 'Server busy' },
-    });
-  });
+    })
+  })
 
   describe('Input validation', () => {
     beforeEach(() => {
       // Setup ensureArrayArgs to return false for this specific test group
-      mockEnsureArrayArgs.mockReturnValue(false);
-    });
+      mockEnsureArrayArgs.mockReturnValue(false)
+    })
 
     it('should reject non-array arguments', async () => {
       // Call the function with non-array args
-      await eth_getTransactionByBlockHashAndIndex({ invalid: true } as RequestParamsLike, mockCallback);
-      
+      await eth_getTransactionByBlockHashAndIndex({ invalid: true } as RequestParamsLike, mockCallback)
+
       // Verify behavior
-      expect(mockNestedCountersInstance.countEvent).toHaveBeenCalledWith('endpoint', 'eth_getTransactionByBlockHashAndIndex');
-      expect(mockEnsureArrayArgs).toHaveBeenCalledWith({ invalid: true }, mockCallback);
-      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockHashAndIndex', 'Invalid params: non-array args');
-      expect(mockCallback).not.toHaveBeenCalled();
-    });
-  });
+      expect(mockNestedCountersInstance.countEvent).toHaveBeenCalledWith(
+        'endpoint',
+        'eth_getTransactionByBlockHashAndIndex'
+      )
+      expect(mockEnsureArrayArgs).toHaveBeenCalledWith({ invalid: true }, mockCallback)
+      expect(mockCountFailedResponse).toHaveBeenCalledWith(
+        'eth_getTransactionByBlockHashAndIndex',
+        'Invalid params: non-array args'
+      )
+      expect(mockCallback).not.toHaveBeenCalled()
+    })
+  })
 
   describe('Collector API path', () => {
     beforeEach(() => {
       // Setup ensureArrayArgs to return true for this test group
-      mockEnsureArrayArgs.mockReturnValue(true);
-    });
+      mockEnsureArrayArgs.mockReturnValue(true)
+    })
 
     it('should return transaction from collector when available', async () => {
       const mockTransaction: Partial<completeReadableReceipt> = {
         blockHash: blockHash,
         transactionIndex: '0x1',
-      };
-      
+      }
+
       // Mock the collectorAPI.getBlock response
       mockCollectorAPI.getBlock.mockResolvedValue({
-        transactions: [mockTransaction, mockTransaction]
-      });
-      
+        transactions: [mockTransaction, mockTransaction],
+      })
+
       // Call the function
-      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback)
+
       // Verify behavior
-      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockHash, 'hash', true);
-      expect(mockCallback).toHaveBeenCalledWith(null, mockTransaction);
-      expect(mockCountSuccessResponse).toHaveBeenCalledWith('eth_getTransactionByBlockHashAndIndex', 'success', 'collector');
-    });
+      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockHash, 'hash', true)
+      expect(mockCallback).toHaveBeenCalledWith(null, mockTransaction)
+      expect(mockCountSuccessResponse).toHaveBeenCalledWith(
+        'eth_getTransactionByBlockHashAndIndex',
+        'success',
+        'collector'
+      )
+    })
 
     it('should adjust transactionIndex to match the input index', async () => {
       const mockTransaction: Partial<completeReadableReceipt> = {
         blockHash: blockHash,
         transactionIndex: '0x0', // Intentionally different from input index
-      };
-      
+      }
+
       // Mock the collectorAPI.getBlock response
       mockCollectorAPI.getBlock.mockResolvedValue({
-        transactions: [mockTransaction, mockTransaction]
-      });
-      
+        transactions: [mockTransaction, mockTransaction],
+      })
+
       // Call the function
-      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback)
+
       // Verify behavior
-      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockHash, 'hash', true);
+      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockHash, 'hash', true)
       // The transaction object should be returned with transactionIndex adjusted
       expect(mockCallback).toHaveBeenCalledWith(null, {
         ...mockTransaction,
-        transactionIndex: '0x1' // Should match the input index
-      });
-    });
+        transactionIndex: '0x1', // Should match the input index
+      })
+    })
 
     it('should handle exception from collector API', async () => {
       // Mock the collectorAPI.getBlock to throw an error
-      mockCollectorAPI.getBlock.mockRejectedValue(new Error('Collector API error'));
-      
+      mockCollectorAPI.getBlock.mockRejectedValue(new Error('Collector API error'))
+
       // Call the function
-      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback)
+
       // Verify behavior
-      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockHash, 'hash', true);
-      expect(mockCallback).toHaveBeenCalledWith({ code: -32005, message: 'Server busy' });
-      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockHashAndIndex', 'exception in collectorAPI.getBlock');
-    });
-  });
+      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockHash, 'hash', true)
+      expect(mockCallback).toHaveBeenCalledWith({ code: -32005, message: 'Server busy' })
+      expect(mockCountFailedResponse).toHaveBeenCalledWith(
+        'eth_getTransactionByBlockHashAndIndex',
+        'exception in collectorAPI.getBlock'
+      )
+    })
+  })
 
   describe('Explorer API path', () => {
     beforeEach(() => {
       // Setup ensureArrayArgs to return true for this test group
-      mockEnsureArrayArgs.mockReturnValue(true);
-      
+      mockEnsureArrayArgs.mockReturnValue(true)
+
       // Setup collector API to return empty results for the Explorer path tests
       mockCollectorAPI.getBlock.mockResolvedValue({
-        transactions: []
-      });
-    });
+        transactions: [],
+      })
+    })
 
     it('should fetch transaction from explorer when collector API has no result', async () => {
       // Setup mock explorer response
       const mockExplorerResponse = {
         data: {
           success: true,
-          transactions: [
-            { id: 'tx1' },
-            { id: 'tx2' }
-          ]
-        }
-      };
-      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
-      
+          transactions: [{ id: 'tx1' }, { id: 'tx2' }],
+        },
+      }
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse)
+
       // Setup extractTransactionObject to return a mock transaction
-      const mockExtractedTx = { hash: '0xabc', blockHash };
-      mockExtractTransactionObject.mockReturnValue(mockExtractedTx);
-      
+      const mockExtractedTx = { hash: '0xabc', blockHash }
+      mockExtractTransactionObject.mockReturnValue(mockExtractedTx)
+
       // Call the function
-      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback)
+
       // Verify behavior
-      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockHash=${blockHash}`);
-      expect(mockExtractTransactionObject).toHaveBeenCalledWith(mockExplorerResponse.data.transactions[1], 1);
-      expect(mockCallback).toHaveBeenCalledWith(null, mockExtractedTx);
-      expect(mockCountSuccessResponse).toHaveBeenCalledWith('eth_getTransactionByBlockHashAndIndex', 'success', 'explorer');
-    });
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockHash=${blockHash}`)
+      expect(mockExtractTransactionObject).toHaveBeenCalledWith(mockExplorerResponse.data.transactions[1], 1)
+      expect(mockCallback).toHaveBeenCalledWith(null, mockExtractedTx)
+      expect(mockCountSuccessResponse).toHaveBeenCalledWith(
+        'eth_getTransactionByBlockHashAndIndex',
+        'success',
+        'explorer'
+      )
+    })
 
     it('should handle explorer API errors', async () => {
       // Setup mock explorer to throw an error
-      mockedAxios.get.mockRejectedValue(new Error('Explorer API error'));
-      
+      mockedAxios.get.mockRejectedValue(new Error('Explorer API error'))
+
       // Call the function
-      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback)
+
       // Verify behavior
-      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockHash=${blockHash}`);
-      expect(mockCallback).toHaveBeenCalledWith(null, null);
-      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockHashAndIndex', 'exception in axios.get');
-    });
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockHash=${blockHash}`)
+      expect(mockCallback).toHaveBeenCalledWith(null, null)
+      expect(mockCountFailedResponse).toHaveBeenCalledWith(
+        'eth_getTransactionByBlockHashAndIndex',
+        'exception in axios.get'
+      )
+    })
 
     it('should handle invalid index gracefully', async () => {
-      const outOfBoundsIndex = '0x5'; // Index that's out of bounds
-      
+      const outOfBoundsIndex = '0x5' // Index that's out of bounds
+
       // Setup mock explorer response with fewer transactions than the index
       const mockExplorerResponse = {
         data: {
           success: true,
-          transactions: [
-            { id: 'tx1' },
-            { id: 'tx2' }
-          ]
-        }
-      };
-      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
-      
+          transactions: [{ id: 'tx1' }, { id: 'tx2' }],
+        },
+      }
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse)
+
       // Call the function
-      await eth_getTransactionByBlockHashAndIndex([blockHash, outOfBoundsIndex], mockCallback);
-      
+      await eth_getTransactionByBlockHashAndIndex([blockHash, outOfBoundsIndex], mockCallback)
+
       // Verify behavior
-      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockHash=${blockHash}`);
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockHash=${blockHash}`)
       // extractTransactionObject shouldn't be called since index is invalid
-      expect(mockExtractTransactionObject).not.toHaveBeenCalled();
-      
+      expect(mockExtractTransactionObject).not.toHaveBeenCalled()
+
       // The implementation calls callback twice:
       // First in the explorer path with null (no result)
-      expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined);
+      expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined)
       // Then again at the end of the function with the original result variable (still undefined)
-      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined);
-      expect(mockCallback).toHaveBeenCalledTimes(2);
-    });
+      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined)
+      expect(mockCallback).toHaveBeenCalledTimes(2)
+    })
 
     it('should handle explorer unsuccessful response', async () => {
       // Setup mock explorer response with success: false
       const mockExplorerResponse = {
         data: {
           success: false,
-          transactions: []
-        }
-      };
-      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
-      
+          transactions: [],
+        },
+      }
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse)
+
       // Call the function
-      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockHashAndIndex([blockHash, txIndex], mockCallback)
+
       // Verify behavior
-      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockHash=${blockHash}`);
-      
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockHash=${blockHash}`)
+
       // The implementation calls callback twice:
       // First in the explorer path with null (unsuccessful response)
-      expect(mockCallback).toHaveBeenNthCalledWith(1, null, null);
+      expect(mockCallback).toHaveBeenNthCalledWith(1, null, null)
       // Then again at the end of the function with the original result variable (undefined in the refactored test)
-      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined);
-      expect(mockCallback).toHaveBeenCalledTimes(2);
-    });
-  });
+      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined)
+      expect(mockCallback).toHaveBeenCalledTimes(2)
+    })
+  })
 
   describe('Configuration state handling', () => {
     beforeEach(() => {
       // Setup ensureArrayArgs to return true for this test group
-      mockEnsureArrayArgs.mockReturnValue(true);
-      
+      mockEnsureArrayArgs.mockReturnValue(true)
+
       // Setup collector API to return null
       mockCollectorAPI.getBlock.mockResolvedValue({
-        transactions: []
-      });
-    });
+        transactions: [],
+      })
+    })
 
     it('should handle disabled queryFromValidator and queryFromExplorer', async () => {
       // Disable both config options
       const disabledConfig = {
         ...mockConfig,
         queryFromValidator: false,
-        queryFromExplorer: false
-      };
-      
+        queryFromExplorer: false,
+      }
+
       // Rebuild handler with disabled config
       const handlerWithDisabledConfig = buildGetTransactionByBlockHashAndIndex({
         nestedCountersInstance: mockNestedCountersInstance,
@@ -295,14 +309,17 @@ describe('eth_getTransactionByBlockHashAndIndex handler', () => {
         config: disabledConfig,
         verbose: false,
         errorBusy: { code: -32005, message: 'Server busy' },
-      });
-      
+      })
+
       // Call the function
-      await handlerWithDisabledConfig([blockHash, txIndex], mockCallback);
-      
+      await handlerWithDisabledConfig([blockHash, txIndex], mockCallback)
+
       // Verify behavior
-      expect(mockCallback).toHaveBeenCalledWith(null, null);
-      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockHashAndIndex', 'queryFromValidator and/or queryFromExplorer turned off');
-    });
-  });
-}); 
+      expect(mockCallback).toHaveBeenCalledWith(null, null)
+      expect(mockCountFailedResponse).toHaveBeenCalledWith(
+        'eth_getTransactionByBlockHashAndIndex',
+        'queryFromValidator and/or queryFromExplorer turned off'
+      )
+    })
+  })
+})

--- a/test/unit/eth-handlers/eth_getTransactionByBlockNumberAndIndex.test.ts
+++ b/test/unit/eth-handlers/eth_getTransactionByBlockNumberAndIndex.test.ts
@@ -1,0 +1,386 @@
+import { buildGetTransactionByBlockNumberAndIndex } from '../../../src/eth-handlers/eth_getTransactionByBlockNumberAndIndex';
+import axios from 'axios';
+import { completeReadableReceipt } from '../../../src/external/Collector';
+import { RequestParamsLike } from 'jayson';
+
+// Mock dependencies
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Mock crypto for the ticket generation
+jest.mock('crypto', () => ({
+  createHash: jest.fn().mockReturnValue({
+    update: jest.fn().mockReturnValue({
+      digest: jest.fn().mockReturnValue('test-ticket-hash'),
+    }),
+  }),
+}));
+
+describe('eth_getTransactionByBlockNumberAndIndex handler', () => {
+  // Common test values
+  const blockNumber = '0x1234';
+  const blockNumberTag = 'latest';
+  const txIndex = '0x1';
+  
+  // Declare mocks
+  let mockNestedCountersInstance: any;
+  let mockEnsureArrayArgs: jest.Mock;
+  let mockCountFailedResponse: jest.Mock;
+  let mockLogEventEmitter: any;
+  let mockCollectorAPI: any;
+  let mockExtractTransactionObject: jest.Mock;
+  let mockCountSuccessResponse: jest.Mock;
+  let mockConfig: any;
+  let mockCallback: jest.Mock;
+  let eth_getTransactionByBlockNumberAndIndex: any;
+
+  // Initialize all mocks before each test
+  beforeEach(() => {
+    // Create fresh mocks for all dependencies
+    mockNestedCountersInstance = {
+      countEvent: jest.fn(),
+    };
+    mockEnsureArrayArgs = jest.fn();
+    mockCountFailedResponse = jest.fn();
+    mockLogEventEmitter = {
+      emit: jest.fn(),
+    };
+    mockCollectorAPI = {
+      getBlock: jest.fn(),
+    };
+    mockExtractTransactionObject = jest.fn();
+    mockCountSuccessResponse = jest.fn();
+    mockConfig = {
+      queryFromValidator: true,
+      queryFromExplorer: true,
+      explorerUrl: 'https://explorer.example.com'
+    };
+    mockCallback = jest.fn();
+
+    // Reset axios mock
+    mockedAxios.get.mockReset();
+
+    // Build the handler function with fresh mocks
+    eth_getTransactionByBlockNumberAndIndex = buildGetTransactionByBlockNumberAndIndex({
+      nestedCountersInstance: mockNestedCountersInstance,
+      ensureArrayArgs: mockEnsureArrayArgs,
+      countFailedResponse: mockCountFailedResponse,
+      logEventEmitter: mockLogEventEmitter,
+      firstLineLogs: false,
+      collectorAPI: mockCollectorAPI,
+      extractTransactionObject: mockExtractTransactionObject,
+      countSuccessResponse: mockCountSuccessResponse,
+      config: mockConfig,
+      verbose: false,
+      errorBusy: { code: -32005, message: 'Server busy' },
+    });
+  });
+
+  describe('Input validation', () => {
+    beforeEach(() => {
+      // Setup ensureArrayArgs to return false for this specific test group
+      mockEnsureArrayArgs.mockReturnValue(false);
+    });
+
+    it('should reject non-array arguments', async () => {
+      // Call the function with non-array args
+      await eth_getTransactionByBlockNumberAndIndex({ invalid: true } as RequestParamsLike, mockCallback);
+      
+      // Verify behavior
+      expect(mockNestedCountersInstance.countEvent).toHaveBeenCalledWith('endpoint', 'eth_getTransactionByBlockNumberAndIndex');
+      expect(mockEnsureArrayArgs).toHaveBeenCalledWith({ invalid: true }, mockCallback);
+      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'Invalid params: non-array args');
+      expect(mockCallback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Collector API path', () => {
+    beforeEach(() => {
+      // Setup ensureArrayArgs to return true for this test group
+      mockEnsureArrayArgs.mockReturnValue(true);
+    });
+
+    it('should return transaction from collector when available with hex block number', async () => {
+      const mockTransaction: Partial<completeReadableReceipt> = {
+        blockNumber: blockNumber,
+        transactionIndex: '0x1',
+      };
+      
+      // Mock the collectorAPI.getBlock response
+      mockCollectorAPI.getBlock.mockResolvedValue({
+        transactions: [mockTransaction, mockTransaction]
+      });
+      
+      // Call the function
+      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback);
+      
+      // Verify behavior
+      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockNumber, 'hex_num', true);
+      expect(mockCallback).toHaveBeenCalledWith(null, mockTransaction);
+      expect(mockCountSuccessResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'success', 'collector');
+    });
+
+    it('should return transaction from collector when available with "latest" tag', async () => {
+      const mockTransaction: Partial<completeReadableReceipt> = {
+        blockNumber: '0x10',
+        transactionIndex: '0x1',
+      };
+      
+      // Mock the collectorAPI.getBlock response
+      mockCollectorAPI.getBlock.mockResolvedValue({
+        transactions: [mockTransaction, mockTransaction]
+      });
+      
+      // Call the function
+      await eth_getTransactionByBlockNumberAndIndex([blockNumberTag, txIndex], mockCallback);
+      
+      // Verify behavior
+      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockNumberTag, 'hex_num', true);
+      expect(mockCallback).toHaveBeenCalledWith(null, mockTransaction);
+      expect(mockCountSuccessResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'success', 'collector');
+    });
+
+    it('should adjust transactionIndex to match the input index', async () => {
+      const mockTransaction: Partial<completeReadableReceipt> = {
+        blockNumber: blockNumber,
+        transactionIndex: '0x0', // Intentionally different from input index
+      };
+      
+      // Mock the collectorAPI.getBlock response
+      mockCollectorAPI.getBlock.mockResolvedValue({
+        transactions: [mockTransaction, mockTransaction]
+      });
+      
+      // Call the function
+      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback);
+      
+      // Verify behavior
+      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockNumber, 'hex_num', true);
+      // The transaction object should be returned with transactionIndex adjusted
+      expect(mockCallback).toHaveBeenCalledWith(null, {
+        ...mockTransaction,
+        transactionIndex: '0x1' // Should match the input index
+      });
+    });
+
+    it('should handle exception from collector API', async () => {
+      // Mock the collectorAPI.getBlock to throw an error
+      mockCollectorAPI.getBlock.mockRejectedValue(new Error('Collector API error'));
+      
+      // Call the function
+      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback);
+      
+      // Verify behavior
+      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockNumber, 'hex_num', true);
+      expect(mockCallback).toHaveBeenCalledWith({ code: -32005, message: 'Server busy' });
+      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'exception in collectorAPI.getBlock');
+    });
+  });
+
+  describe('Explorer API path', () => {
+    beforeEach(() => {
+      // Setup ensureArrayArgs to return true for this test group
+      mockEnsureArrayArgs.mockReturnValue(true);
+      
+      // Setup collector API to return empty results for the Explorer path tests
+      mockCollectorAPI.getBlock.mockResolvedValue({
+        transactions: []
+      });
+    });
+
+    it('should fetch transaction from explorer when collector API has no result with hex block number', async () => {
+      // Setup mock explorer response
+      const mockExplorerResponse = {
+        data: {
+          success: true,
+          transactions: [
+            { id: 'tx1' },
+            { id: 'tx2' }
+          ]
+        }
+      };
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
+      
+      // Setup extractTransactionObject to return a mock transaction
+      const mockExtractedTx = { hash: '0xabc', blockNumber };
+      mockExtractTransactionObject.mockReturnValue(mockExtractedTx);
+      
+      // Call the function
+      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback);
+      
+      // Verify behavior
+      // Should convert hex block number to decimal
+      const decimalBlockNumber = parseInt(blockNumber, 16);
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockNumber=${decimalBlockNumber}`);
+      expect(mockExtractTransactionObject).toHaveBeenCalledWith(mockExplorerResponse.data.transactions[1], 1);
+      expect(mockCallback).toHaveBeenCalledWith(null, mockExtractedTx);
+      expect(mockCountSuccessResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'success', 'explorer');
+    });
+
+    it('should fetch transaction from explorer with "latest" block tag', async () => {
+      // Setup mock explorer response
+      const mockExplorerResponse = {
+        data: {
+          success: true,
+          transactions: [
+            { id: 'tx1' },
+            { id: 'tx2' }
+          ]
+        }
+      };
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
+      
+      // Setup extractTransactionObject to return a mock transaction
+      const mockExtractedTx = { hash: '0xabc', blockNumber: 'latest' };
+      mockExtractTransactionObject.mockReturnValue(mockExtractedTx);
+      
+      // Call the function
+      await eth_getTransactionByBlockNumberAndIndex([blockNumberTag, txIndex], mockCallback);
+      
+      // Verify behavior
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockNumber=${blockNumberTag}`);
+      expect(mockExtractTransactionObject).toHaveBeenCalledWith(mockExplorerResponse.data.transactions[1], 1);
+      expect(mockCallback).toHaveBeenCalledWith(null, mockExtractedTx);
+      expect(mockCountSuccessResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'success', 'explorer');
+    });
+
+    it('should handle explorer API errors', async () => {
+      // Setup mock explorer to throw an error
+      mockedAxios.get.mockRejectedValue(new Error('Explorer API error'));
+      
+      // Call the function
+      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback);
+      
+      // Verify behavior
+      const decimalBlockNumber = parseInt(blockNumber, 16);
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockNumber=${decimalBlockNumber}`);
+      expect(mockCallback).toHaveBeenCalledWith(null, null);
+      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'exception in axios.get');
+    });
+
+    it('should handle invalid index gracefully', async () => {
+      const outOfBoundsIndex = '0x5'; // Index that's out of bounds
+      
+      // Setup mock explorer response with fewer transactions than the index
+      const mockExplorerResponse = {
+        data: {
+          success: true,
+          transactions: [
+            { id: 'tx1' },
+            { id: 'tx2' }
+          ]
+        }
+      };
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
+      
+      // Call the function
+      await eth_getTransactionByBlockNumberAndIndex([blockNumber, outOfBoundsIndex], mockCallback);
+      
+      // Verify behavior
+      const decimalBlockNumber = parseInt(blockNumber, 16);
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockNumber=${decimalBlockNumber}`);
+      // extractTransactionObject shouldn't be called since index is invalid
+      expect(mockExtractTransactionObject).not.toHaveBeenCalled();
+      
+      // The implementation calls callback twice:
+      // First in the explorer path with null (no result)
+      expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined);
+      // Then again at the end of the function with the original result variable (still undefined)
+      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined);
+      expect(mockCallback).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle explorer unsuccessful response', async () => {
+      // Setup mock explorer response with success: false
+      const mockExplorerResponse = {
+        data: {
+          success: false,
+          transactions: []
+        }
+      };
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
+      
+      // Call the function
+      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback);
+      
+      // Verify behavior
+      const decimalBlockNumber = parseInt(blockNumber, 16);
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockNumber=${decimalBlockNumber}`);
+      
+      // The implementation calls callback twice:
+      // First in the explorer path with null (unsuccessful response)
+      expect(mockCallback).toHaveBeenNthCalledWith(1, null, null);
+      // Then again at the end of the function with the original result variable (undefined in the refactored test)
+      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined);
+      expect(mockCallback).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle "earliest" block tag correctly', async () => {
+      // Setup mock explorer response
+      const mockExplorerResponse = {
+        data: {
+          success: true,
+          transactions: [
+            { id: 'tx1' },
+            { id: 'tx2' }
+          ]
+        }
+      };
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
+      
+      // Setup extractTransactionObject to return a mock transaction
+      const mockExtractedTx = { hash: '0xabc', blockNumber: '0x0' };
+      mockExtractTransactionObject.mockReturnValue(mockExtractedTx);
+      
+      // Call the function with "earliest" tag
+      await eth_getTransactionByBlockNumberAndIndex(['earliest', txIndex], mockCallback);
+      
+      // Verify behavior - should convert "earliest" to 0
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockNumber=0`);
+      expect(mockExtractTransactionObject).toHaveBeenCalledWith(mockExplorerResponse.data.transactions[1], 1);
+      expect(mockCallback).toHaveBeenCalledWith(null, mockExtractedTx);
+    });
+  });
+
+  describe('Configuration state handling', () => {
+    beforeEach(() => {
+      // Setup ensureArrayArgs to return true for this test group
+      mockEnsureArrayArgs.mockReturnValue(true);
+      
+      // Setup collector API to return null
+      mockCollectorAPI.getBlock.mockResolvedValue({
+        transactions: []
+      });
+    });
+
+    it('should handle disabled queryFromExplorer', async () => {
+      // Disable config option
+      const disabledConfig = {
+        ...mockConfig,
+        queryFromExplorer: false
+      };
+      
+      // Rebuild handler with disabled config
+      const handlerWithDisabledConfig = buildGetTransactionByBlockNumberAndIndex({
+        nestedCountersInstance: mockNestedCountersInstance,
+        ensureArrayArgs: mockEnsureArrayArgs,
+        countFailedResponse: mockCountFailedResponse,
+        logEventEmitter: mockLogEventEmitter,
+        firstLineLogs: false,
+        collectorAPI: mockCollectorAPI,
+        extractTransactionObject: mockExtractTransactionObject,
+        countSuccessResponse: mockCountSuccessResponse,
+        config: disabledConfig,
+        verbose: false,
+        errorBusy: { code: -32005, message: 'Server busy' },
+      });
+      
+      // Call the function
+      await handlerWithDisabledConfig([blockNumber, txIndex], mockCallback);
+      
+      // Verify behavior
+      expect(mockCallback).toHaveBeenCalledWith(null, null);
+      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'queryFromExplorer turned off');
+    });
+  });
+}); 

--- a/test/unit/eth-handlers/eth_getTransactionByBlockNumberAndIndex.test.ts
+++ b/test/unit/eth-handlers/eth_getTransactionByBlockNumberAndIndex.test.ts
@@ -1,11 +1,11 @@
-import { buildGetTransactionByBlockNumberAndIndex } from '../../../src/eth-handlers/eth_getTransactionByBlockNumberAndIndex';
-import axios from 'axios';
-import { completeReadableReceipt } from '../../../src/external/Collector';
-import { RequestParamsLike } from 'jayson';
+import { buildGetTransactionByBlockNumberAndIndex } from '../../../src/eth-handlers/eth_getTransactionByBlockNumberAndIndex'
+import axios from 'axios'
+import { completeReadableReceipt } from '../../../src/external/Collector'
+import { RequestParamsLike } from 'jayson'
 
 // Mock dependencies
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>
 
 // Mock crypto for the ticket generation
 jest.mock('crypto', () => ({
@@ -14,51 +14,51 @@ jest.mock('crypto', () => ({
       digest: jest.fn().mockReturnValue('test-ticket-hash'),
     }),
   }),
-}));
+}))
 
 describe('eth_getTransactionByBlockNumberAndIndex handler', () => {
   // Common test values
-  const blockNumber = '0x1234';
-  const blockNumberTag = 'latest';
-  const txIndex = '0x1';
-  
+  const blockNumber = '0x1234'
+  const blockNumberTag = 'latest'
+  const txIndex = '0x1'
+
   // Declare mocks
-  let mockNestedCountersInstance: any;
-  let mockEnsureArrayArgs: jest.Mock;
-  let mockCountFailedResponse: jest.Mock;
-  let mockLogEventEmitter: any;
-  let mockCollectorAPI: any;
-  let mockExtractTransactionObject: jest.Mock;
-  let mockCountSuccessResponse: jest.Mock;
-  let mockConfig: any;
-  let mockCallback: jest.Mock;
-  let eth_getTransactionByBlockNumberAndIndex: any;
+  let mockNestedCountersInstance: any
+  let mockEnsureArrayArgs: jest.Mock
+  let mockCountFailedResponse: jest.Mock
+  let mockLogEventEmitter: any
+  let mockCollectorAPI: any
+  let mockExtractTransactionObject: jest.Mock
+  let mockCountSuccessResponse: jest.Mock
+  let mockConfig: any
+  let mockCallback: jest.Mock
+  let eth_getTransactionByBlockNumberAndIndex: any
 
   // Initialize all mocks before each test
   beforeEach(() => {
     // Create fresh mocks for all dependencies
     mockNestedCountersInstance = {
       countEvent: jest.fn(),
-    };
-    mockEnsureArrayArgs = jest.fn();
-    mockCountFailedResponse = jest.fn();
+    }
+    mockEnsureArrayArgs = jest.fn()
+    mockCountFailedResponse = jest.fn()
     mockLogEventEmitter = {
       emit: jest.fn(),
-    };
+    }
     mockCollectorAPI = {
       getBlock: jest.fn(),
-    };
-    mockExtractTransactionObject = jest.fn();
-    mockCountSuccessResponse = jest.fn();
+    }
+    mockExtractTransactionObject = jest.fn()
+    mockCountSuccessResponse = jest.fn()
     mockConfig = {
       queryFromValidator: true,
       queryFromExplorer: true,
-      explorerUrl: 'https://explorer.example.com'
-    };
-    mockCallback = jest.fn();
+      explorerUrl: 'https://explorer.example.com',
+    }
+    mockCallback = jest.fn()
 
     // Reset axios mock
-    mockedAxios.get.mockReset();
+    mockedAxios.get.mockReset()
 
     // Build the handler function with fresh mocks
     eth_getTransactionByBlockNumberAndIndex = buildGetTransactionByBlockNumberAndIndex({
@@ -73,293 +73,319 @@ describe('eth_getTransactionByBlockNumberAndIndex handler', () => {
       config: mockConfig,
       verbose: false,
       errorBusy: { code: -32005, message: 'Server busy' },
-    });
-  });
+    })
+  })
 
   describe('Input validation', () => {
     beforeEach(() => {
       // Setup ensureArrayArgs to return false for this specific test group
-      mockEnsureArrayArgs.mockReturnValue(false);
-    });
+      mockEnsureArrayArgs.mockReturnValue(false)
+    })
 
     it('should reject non-array arguments', async () => {
       // Call the function with non-array args
-      await eth_getTransactionByBlockNumberAndIndex({ invalid: true } as RequestParamsLike, mockCallback);
-      
+      await eth_getTransactionByBlockNumberAndIndex({ invalid: true } as RequestParamsLike, mockCallback)
+
       // Verify behavior
-      expect(mockNestedCountersInstance.countEvent).toHaveBeenCalledWith('endpoint', 'eth_getTransactionByBlockNumberAndIndex');
-      expect(mockEnsureArrayArgs).toHaveBeenCalledWith({ invalid: true }, mockCallback);
-      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'Invalid params: non-array args');
-      expect(mockCallback).not.toHaveBeenCalled();
-    });
-  });
+      expect(mockNestedCountersInstance.countEvent).toHaveBeenCalledWith(
+        'endpoint',
+        'eth_getTransactionByBlockNumberAndIndex'
+      )
+      expect(mockEnsureArrayArgs).toHaveBeenCalledWith({ invalid: true }, mockCallback)
+      expect(mockCountFailedResponse).toHaveBeenCalledWith(
+        'eth_getTransactionByBlockNumberAndIndex',
+        'Invalid params: non-array args'
+      )
+      expect(mockCallback).not.toHaveBeenCalled()
+    })
+  })
 
   describe('Collector API path', () => {
     beforeEach(() => {
       // Setup ensureArrayArgs to return true for this test group
-      mockEnsureArrayArgs.mockReturnValue(true);
-    });
+      mockEnsureArrayArgs.mockReturnValue(true)
+    })
 
     it('should return transaction from collector when available with hex block number', async () => {
       const mockTransaction: Partial<completeReadableReceipt> = {
         blockNumber: blockNumber,
         transactionIndex: '0x1',
-      };
-      
+      }
+
       // Mock the collectorAPI.getBlock response
       mockCollectorAPI.getBlock.mockResolvedValue({
-        transactions: [mockTransaction, mockTransaction]
-      });
-      
+        transactions: [mockTransaction, mockTransaction],
+      })
+
       // Call the function
-      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback)
+
       // Verify behavior
-      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockNumber, 'hex_num', true);
-      expect(mockCallback).toHaveBeenCalledWith(null, mockTransaction);
-      expect(mockCountSuccessResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'success', 'collector');
-    });
+      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockNumber, 'hex_num', true)
+      expect(mockCallback).toHaveBeenCalledWith(null, mockTransaction)
+      expect(mockCountSuccessResponse).toHaveBeenCalledWith(
+        'eth_getTransactionByBlockNumberAndIndex',
+        'success',
+        'collector'
+      )
+    })
 
     it('should return transaction from collector when available with "latest" tag', async () => {
       const mockTransaction: Partial<completeReadableReceipt> = {
         blockNumber: '0x10',
         transactionIndex: '0x1',
-      };
-      
+      }
+
       // Mock the collectorAPI.getBlock response
       mockCollectorAPI.getBlock.mockResolvedValue({
-        transactions: [mockTransaction, mockTransaction]
-      });
-      
+        transactions: [mockTransaction, mockTransaction],
+      })
+
       // Call the function
-      await eth_getTransactionByBlockNumberAndIndex([blockNumberTag, txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockNumberAndIndex([blockNumberTag, txIndex], mockCallback)
+
       // Verify behavior
-      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockNumberTag, 'hex_num', true);
-      expect(mockCallback).toHaveBeenCalledWith(null, mockTransaction);
-      expect(mockCountSuccessResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'success', 'collector');
-    });
+      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockNumberTag, 'hex_num', true)
+      expect(mockCallback).toHaveBeenCalledWith(null, mockTransaction)
+      expect(mockCountSuccessResponse).toHaveBeenCalledWith(
+        'eth_getTransactionByBlockNumberAndIndex',
+        'success',
+        'collector'
+      )
+    })
 
     it('should adjust transactionIndex to match the input index', async () => {
       const mockTransaction: Partial<completeReadableReceipt> = {
         blockNumber: blockNumber,
         transactionIndex: '0x0', // Intentionally different from input index
-      };
-      
+      }
+
       // Mock the collectorAPI.getBlock response
       mockCollectorAPI.getBlock.mockResolvedValue({
-        transactions: [mockTransaction, mockTransaction]
-      });
-      
+        transactions: [mockTransaction, mockTransaction],
+      })
+
       // Call the function
-      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback)
+
       // Verify behavior
-      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockNumber, 'hex_num', true);
+      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockNumber, 'hex_num', true)
       // The transaction object should be returned with transactionIndex adjusted
       expect(mockCallback).toHaveBeenCalledWith(null, {
         ...mockTransaction,
-        transactionIndex: '0x1' // Should match the input index
-      });
-    });
+        transactionIndex: '0x1', // Should match the input index
+      })
+    })
 
     it('should handle exception from collector API', async () => {
       // Mock the collectorAPI.getBlock to throw an error
-      mockCollectorAPI.getBlock.mockRejectedValue(new Error('Collector API error'));
-      
+      mockCollectorAPI.getBlock.mockRejectedValue(new Error('Collector API error'))
+
       // Call the function
-      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback)
+
       // Verify behavior
-      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockNumber, 'hex_num', true);
-      expect(mockCallback).toHaveBeenCalledWith({ code: -32005, message: 'Server busy' });
-      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'exception in collectorAPI.getBlock');
-    });
-  });
+      expect(mockCollectorAPI.getBlock).toHaveBeenCalledWith(blockNumber, 'hex_num', true)
+      expect(mockCallback).toHaveBeenCalledWith({ code: -32005, message: 'Server busy' })
+      expect(mockCountFailedResponse).toHaveBeenCalledWith(
+        'eth_getTransactionByBlockNumberAndIndex',
+        'exception in collectorAPI.getBlock'
+      )
+    })
+  })
 
   describe('Explorer API path', () => {
     beforeEach(() => {
       // Setup ensureArrayArgs to return true for this test group
-      mockEnsureArrayArgs.mockReturnValue(true);
-      
+      mockEnsureArrayArgs.mockReturnValue(true)
+
       // Setup collector API to return empty results for the Explorer path tests
       mockCollectorAPI.getBlock.mockResolvedValue({
-        transactions: []
-      });
-    });
+        transactions: [],
+      })
+    })
 
     it('should fetch transaction from explorer when collector API has no result with hex block number', async () => {
       // Setup mock explorer response
       const mockExplorerResponse = {
         data: {
           success: true,
-          transactions: [
-            { id: 'tx1' },
-            { id: 'tx2' }
-          ]
-        }
-      };
-      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
-      
+          transactions: [{ id: 'tx1' }, { id: 'tx2' }],
+        },
+      }
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse)
+
       // Setup extractTransactionObject to return a mock transaction
-      const mockExtractedTx = { hash: '0xabc', blockNumber };
-      mockExtractTransactionObject.mockReturnValue(mockExtractedTx);
-      
+      const mockExtractedTx = { hash: '0xabc', blockNumber }
+      mockExtractTransactionObject.mockReturnValue(mockExtractedTx)
+
       // Call the function
-      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback)
+
       // Verify behavior
       // Should convert hex block number to decimal
-      const decimalBlockNumber = parseInt(blockNumber, 16);
-      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockNumber=${decimalBlockNumber}`);
-      expect(mockExtractTransactionObject).toHaveBeenCalledWith(mockExplorerResponse.data.transactions[1], 1);
-      expect(mockCallback).toHaveBeenCalledWith(null, mockExtractedTx);
-      expect(mockCountSuccessResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'success', 'explorer');
-    });
+      const decimalBlockNumber = parseInt(blockNumber, 16)
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        `${mockConfig.explorerUrl}/api/transaction?blockNumber=${decimalBlockNumber}`
+      )
+      expect(mockExtractTransactionObject).toHaveBeenCalledWith(mockExplorerResponse.data.transactions[1], 1)
+      expect(mockCallback).toHaveBeenCalledWith(null, mockExtractedTx)
+      expect(mockCountSuccessResponse).toHaveBeenCalledWith(
+        'eth_getTransactionByBlockNumberAndIndex',
+        'success',
+        'explorer'
+      )
+    })
 
     it('should fetch transaction from explorer with "latest" block tag', async () => {
       // Setup mock explorer response
       const mockExplorerResponse = {
         data: {
           success: true,
-          transactions: [
-            { id: 'tx1' },
-            { id: 'tx2' }
-          ]
-        }
-      };
-      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
-      
+          transactions: [{ id: 'tx1' }, { id: 'tx2' }],
+        },
+      }
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse)
+
       // Setup extractTransactionObject to return a mock transaction
-      const mockExtractedTx = { hash: '0xabc', blockNumber: 'latest' };
-      mockExtractTransactionObject.mockReturnValue(mockExtractedTx);
-      
+      const mockExtractedTx = { hash: '0xabc', blockNumber: 'latest' }
+      mockExtractTransactionObject.mockReturnValue(mockExtractedTx)
+
       // Call the function
-      await eth_getTransactionByBlockNumberAndIndex([blockNumberTag, txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockNumberAndIndex([blockNumberTag, txIndex], mockCallback)
+
       // Verify behavior
-      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockNumber=${blockNumberTag}`);
-      expect(mockExtractTransactionObject).toHaveBeenCalledWith(mockExplorerResponse.data.transactions[1], 1);
-      expect(mockCallback).toHaveBeenCalledWith(null, mockExtractedTx);
-      expect(mockCountSuccessResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'success', 'explorer');
-    });
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        `${mockConfig.explorerUrl}/api/transaction?blockNumber=${blockNumberTag}`
+      )
+      expect(mockExtractTransactionObject).toHaveBeenCalledWith(mockExplorerResponse.data.transactions[1], 1)
+      expect(mockCallback).toHaveBeenCalledWith(null, mockExtractedTx)
+      expect(mockCountSuccessResponse).toHaveBeenCalledWith(
+        'eth_getTransactionByBlockNumberAndIndex',
+        'success',
+        'explorer'
+      )
+    })
 
     it('should handle explorer API errors', async () => {
       // Setup mock explorer to throw an error
-      mockedAxios.get.mockRejectedValue(new Error('Explorer API error'));
-      
+      mockedAxios.get.mockRejectedValue(new Error('Explorer API error'))
+
       // Call the function
-      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback)
+
       // Verify behavior
-      const decimalBlockNumber = parseInt(blockNumber, 16);
-      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockNumber=${decimalBlockNumber}`);
-      expect(mockCallback).toHaveBeenCalledWith(null, null);
-      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'exception in axios.get');
-    });
+      const decimalBlockNumber = parseInt(blockNumber, 16)
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        `${mockConfig.explorerUrl}/api/transaction?blockNumber=${decimalBlockNumber}`
+      )
+      expect(mockCallback).toHaveBeenCalledWith(null, null)
+      expect(mockCountFailedResponse).toHaveBeenCalledWith(
+        'eth_getTransactionByBlockNumberAndIndex',
+        'exception in axios.get'
+      )
+    })
 
     it('should handle invalid index gracefully', async () => {
-      const outOfBoundsIndex = '0x5'; // Index that's out of bounds
-      
+      const outOfBoundsIndex = '0x5' // Index that's out of bounds
+
       // Setup mock explorer response with fewer transactions than the index
       const mockExplorerResponse = {
         data: {
           success: true,
-          transactions: [
-            { id: 'tx1' },
-            { id: 'tx2' }
-          ]
-        }
-      };
-      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
-      
+          transactions: [{ id: 'tx1' }, { id: 'tx2' }],
+        },
+      }
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse)
+
       // Call the function
-      await eth_getTransactionByBlockNumberAndIndex([blockNumber, outOfBoundsIndex], mockCallback);
-      
+      await eth_getTransactionByBlockNumberAndIndex([blockNumber, outOfBoundsIndex], mockCallback)
+
       // Verify behavior
-      const decimalBlockNumber = parseInt(blockNumber, 16);
-      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockNumber=${decimalBlockNumber}`);
+      const decimalBlockNumber = parseInt(blockNumber, 16)
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        `${mockConfig.explorerUrl}/api/transaction?blockNumber=${decimalBlockNumber}`
+      )
       // extractTransactionObject shouldn't be called since index is invalid
-      expect(mockExtractTransactionObject).not.toHaveBeenCalled();
-      
+      expect(mockExtractTransactionObject).not.toHaveBeenCalled()
+
       // The implementation calls callback twice:
       // First in the explorer path with null (no result)
-      expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined);
+      expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined)
       // Then again at the end of the function with the original result variable (still undefined)
-      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined);
-      expect(mockCallback).toHaveBeenCalledTimes(2);
-    });
+      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined)
+      expect(mockCallback).toHaveBeenCalledTimes(2)
+    })
 
     it('should handle explorer unsuccessful response', async () => {
       // Setup mock explorer response with success: false
       const mockExplorerResponse = {
         data: {
           success: false,
-          transactions: []
-        }
-      };
-      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
-      
+          transactions: [],
+        },
+      }
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse)
+
       // Call the function
-      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockNumberAndIndex([blockNumber, txIndex], mockCallback)
+
       // Verify behavior
-      const decimalBlockNumber = parseInt(blockNumber, 16);
-      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockNumber=${decimalBlockNumber}`);
-      
+      const decimalBlockNumber = parseInt(blockNumber, 16)
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        `${mockConfig.explorerUrl}/api/transaction?blockNumber=${decimalBlockNumber}`
+      )
+
       // The implementation calls callback twice:
       // First in the explorer path with null (unsuccessful response)
-      expect(mockCallback).toHaveBeenNthCalledWith(1, null, null);
+      expect(mockCallback).toHaveBeenNthCalledWith(1, null, null)
       // Then again at the end of the function with the original result variable (undefined in the refactored test)
-      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined);
-      expect(mockCallback).toHaveBeenCalledTimes(2);
-    });
+      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined)
+      expect(mockCallback).toHaveBeenCalledTimes(2)
+    })
 
     it('should handle "earliest" block tag correctly', async () => {
       // Setup mock explorer response
       const mockExplorerResponse = {
         data: {
           success: true,
-          transactions: [
-            { id: 'tx1' },
-            { id: 'tx2' }
-          ]
-        }
-      };
-      mockedAxios.get.mockResolvedValue(mockExplorerResponse);
-      
+          transactions: [{ id: 'tx1' }, { id: 'tx2' }],
+        },
+      }
+      mockedAxios.get.mockResolvedValue(mockExplorerResponse)
+
       // Setup extractTransactionObject to return a mock transaction
-      const mockExtractedTx = { hash: '0xabc', blockNumber: '0x0' };
-      mockExtractTransactionObject.mockReturnValue(mockExtractedTx);
-      
+      const mockExtractedTx = { hash: '0xabc', blockNumber: '0x0' }
+      mockExtractTransactionObject.mockReturnValue(mockExtractedTx)
+
       // Call the function with "earliest" tag
-      await eth_getTransactionByBlockNumberAndIndex(['earliest', txIndex], mockCallback);
-      
+      await eth_getTransactionByBlockNumberAndIndex(['earliest', txIndex], mockCallback)
+
       // Verify behavior - should convert "earliest" to 0
-      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockNumber=0`);
-      expect(mockExtractTransactionObject).toHaveBeenCalledWith(mockExplorerResponse.data.transactions[1], 1);
-      expect(mockCallback).toHaveBeenCalledWith(null, mockExtractedTx);
-    });
-  });
+      expect(mockedAxios.get).toHaveBeenCalledWith(`${mockConfig.explorerUrl}/api/transaction?blockNumber=0`)
+      expect(mockExtractTransactionObject).toHaveBeenCalledWith(mockExplorerResponse.data.transactions[1], 1)
+      expect(mockCallback).toHaveBeenCalledWith(null, mockExtractedTx)
+    })
+  })
 
   describe('Configuration state handling', () => {
     beforeEach(() => {
       // Setup ensureArrayArgs to return true for this test group
-      mockEnsureArrayArgs.mockReturnValue(true);
-      
+      mockEnsureArrayArgs.mockReturnValue(true)
+
       // Setup collector API to return null
       mockCollectorAPI.getBlock.mockResolvedValue({
-        transactions: []
-      });
-    });
+        transactions: [],
+      })
+    })
 
     it('should handle disabled queryFromExplorer', async () => {
       // Disable config option
       const disabledConfig = {
         ...mockConfig,
-        queryFromExplorer: false
-      };
-      
+        queryFromExplorer: false,
+      }
+
       // Rebuild handler with disabled config
       const handlerWithDisabledConfig = buildGetTransactionByBlockNumberAndIndex({
         nestedCountersInstance: mockNestedCountersInstance,
@@ -373,14 +399,17 @@ describe('eth_getTransactionByBlockNumberAndIndex handler', () => {
         config: disabledConfig,
         verbose: false,
         errorBusy: { code: -32005, message: 'Server busy' },
-      });
-      
+      })
+
       // Call the function
-      await handlerWithDisabledConfig([blockNumber, txIndex], mockCallback);
-      
+      await handlerWithDisabledConfig([blockNumber, txIndex], mockCallback)
+
       // Verify behavior
-      expect(mockCallback).toHaveBeenCalledWith(null, null);
-      expect(mockCountFailedResponse).toHaveBeenCalledWith('eth_getTransactionByBlockNumberAndIndex', 'queryFromExplorer turned off');
-    });
-  });
-}); 
+      expect(mockCallback).toHaveBeenCalledWith(null, null)
+      expect(mockCountFailedResponse).toHaveBeenCalledWith(
+        'eth_getTransactionByBlockNumberAndIndex',
+        'queryFromExplorer turned off'
+      )
+    })
+  })
+})


### PR DESCRIPTION
### **User description**
Correct the incorrect transactionIndex output for `eth_getTransactionByBlockHashAndIndex` and `eth_getTransactionByBlockNumberAndIndex`.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect transaction index in API responses.

- Add undefined check for transaction index.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.ts</strong><dd><code>Correct transaction index and add undefined check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/api.ts

<li>Correct transaction index calculation in API methods.<br> <li> Add check for undefined transaction index.


</details>


  </td>
  <td><a href="https://github.com/shardeum/json-rpc-server/pull/139/files#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>