### PR TITLE
SHARD-2039: Return empty array from eth_accounts instead of hardcoded address

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1023,7 +1023,7 @@ export const methods = {
       .digest('hex')
     logEventEmitter.emit('fn_start', ticket, api_name, performance.now())
     /* prettier-ignore */ if (firstLineLogs) { console.log('Running eth_accounts', args) }
-    const result = ['0x407d73d8a49eeb85d32cf465507dd71d507100c1']
+    const result: string[] = []
 
     logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
     callback(null, result)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Return empty array from `eth_accounts` method.

- Remove hardcoded address from `eth_accounts`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.ts</strong><dd><code>Modify `eth_accounts` to return empty array</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/api.ts

<li>Changed <code>eth_accounts</code> method to return an empty array.<br> <li> Removed hardcoded address from <code>eth_accounts</code> result.


</details>


  </td>
  <td><a href="https://github.com/shardeum/json-rpc-server/pull/140/files#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>