### PR TITLE
SHARD-2052: Limit eth_getTransactionByBlockHashAndIndex and eth_getTransactionByBlockNumberAndIndex to 1 callback per request

### DIFF
--- a/src/eth-handlers/eth_getTransactionByBlockHashAndIndex.ts
+++ b/src/eth-handlers/eth_getTransactionByBlockHashAndIndex.ts
@@ -73,6 +73,7 @@ export const buildGetTransactionByBlockHashAndIndex = ({
       callback(errorBusy)
       countFailedResponse(api_name, 'exception in collectorAPI.getBlock')
       logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
+      return
     }
     const blockHash = (args as any)[0]
     const index = parseInt((args as any)[1], 16)
@@ -104,21 +105,21 @@ export const buildGetTransactionByBlockHashAndIndex = ({
           { nodeUrl, success: res.data.transactions.length ? true : false },
           performance.now()
         )
+        return
       } catch (error) {
         /* prettier-ignore */ if (verbose) console.log('Error: eth_getTransactionByBlockHashAndIndex', (error as AxiosError).message)
         callback(null, null)
         countFailedResponse(api_name, 'exception in axios.get')
         logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
+        return
       }
     } else {
       console.log('queryFromValidator and/or queryFromExplorer turned off. Could not process request')
       callback(null, null)
       countFailedResponse(api_name, 'queryFromValidator and/or queryFromExplorer turned off')
       logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+      return
     }
-    callback(null, result)
-    countSuccessResponse(api_name, 'success', 'fallback')
-    logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
   }
 
   return eth_getTransactionByBlockHashAndIndex

--- a/src/eth-handlers/eth_getTransactionByBlockNumberAndIndex.ts
+++ b/src/eth-handlers/eth_getTransactionByBlockNumberAndIndex.ts
@@ -72,7 +72,9 @@ export const buildGetTransactionByBlockNumberAndIndex = ({
       callback(errorBusy)
       countFailedResponse(api_name, 'exception in collectorAPI.getBlock')
       logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
+      return
     }
+
     /* prettier-ignore */ if (firstLineLogs) { console.log('Running eth_getTransactionByBlockNumberAndIndex', args) }
     let blockNumber = (args as any)[0]
     const index = parseInt((args as any)[1], 16)
@@ -105,21 +107,21 @@ export const buildGetTransactionByBlockNumberAndIndex = ({
           { nodeUrl, success: res.data.transactions.length ? true : false },
           performance.now()
         )
+        return
       } catch (error) {
         /* prettier-ignore */ if (verbose) console.log('Error: eth_getTransactionByBlockNumberAndIndex', (error as AxiosError).message)
         callback(null, null)
         countFailedResponse(api_name, 'exception in axios.get')
         logEventEmitter.emit('fn_end', ticket, { success: false }, performance.now())
+        return
       }
     } else {
       console.log('queryFromExplorer turned off. Could not process request')
       callback(null, null)
       countFailedResponse(api_name, 'queryFromExplorer turned off')
       logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+      return
     }
-    callback(null, result)
-    countSuccessResponse(api_name, 'success', 'fallback')
-    logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
   }
 
   return eth_getTransactionByBlockNumberAndIndex

--- a/test/unit/eth-handlers/eth_getTransactionByBlockHashAndIndex.test.ts
+++ b/test/unit/eth-handlers/eth_getTransactionByBlockHashAndIndex.test.ts
@@ -247,9 +247,7 @@ describe('eth_getTransactionByBlockHashAndIndex handler', () => {
       // The implementation calls callback twice:
       // First in the explorer path with null (no result)
       expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined)
-      // Then again at the end of the function with the original result variable (still undefined)
-      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined)
-      expect(mockCallback).toHaveBeenCalledTimes(2)
+      expect(mockCallback).toHaveBeenCalledTimes(1)
     })
 
     it('should handle explorer unsuccessful response', async () => {
@@ -271,9 +269,7 @@ describe('eth_getTransactionByBlockHashAndIndex handler', () => {
       // The implementation calls callback twice:
       // First in the explorer path with null (unsuccessful response)
       expect(mockCallback).toHaveBeenNthCalledWith(1, null, null)
-      // Then again at the end of the function with the original result variable (undefined in the refactored test)
-      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined)
-      expect(mockCallback).toHaveBeenCalledTimes(2)
+      expect(mockCallback).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/test/unit/eth-handlers/eth_getTransactionByBlockNumberAndIndex.test.ts
+++ b/test/unit/eth-handlers/eth_getTransactionByBlockNumberAndIndex.test.ts
@@ -312,9 +312,7 @@ describe('eth_getTransactionByBlockNumberAndIndex handler', () => {
       // The implementation calls callback twice:
       // First in the explorer path with null (no result)
       expect(mockCallback).toHaveBeenNthCalledWith(1, null, undefined)
-      // Then again at the end of the function with the original result variable (still undefined)
-      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined)
-      expect(mockCallback).toHaveBeenCalledTimes(2)
+      expect(mockCallback).toHaveBeenCalledTimes(1)
     })
 
     it('should handle explorer unsuccessful response', async () => {
@@ -339,9 +337,7 @@ describe('eth_getTransactionByBlockNumberAndIndex handler', () => {
       // The implementation calls callback twice:
       // First in the explorer path with null (unsuccessful response)
       expect(mockCallback).toHaveBeenNthCalledWith(1, null, null)
-      // Then again at the end of the function with the original result variable (undefined in the refactored test)
-      expect(mockCallback).toHaveBeenNthCalledWith(2, null, undefined)
-      expect(mockCallback).toHaveBeenCalledTimes(2)
+      expect(mockCallback).toHaveBeenCalledTimes(1)
     })
 
     it('should handle "earliest" block tag correctly', async () => {


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Ensure single callback execution in eth_getTransactionByBlockHashAndIndex.

- Ensure single callback execution in eth_getTransactionByBlockNumberAndIndex.

- Update unit tests to verify single callback execution.

- Improve error handling with additional return statements.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>eth_getTransactionByBlockHashAndIndex.ts</strong><dd><code>Prevent multiple callbacks in eth_getTransactionByBlockHashAndIndex</code></dd></summary>
<hr>

src/eth-handlers/eth_getTransactionByBlockHashAndIndex.ts

<li>Added return statements to prevent multiple callbacks.<br> <li> Improved error handling with early returns.


</details>


  </td>
  <td><a href="https://github.com/shardeum/json-rpc-server/pull/141/files#diff-5cbd82f6c0e4de7295d1565e018af74af3f04a392df9d2d02574838e6007fc53">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>eth_getTransactionByBlockNumberAndIndex.ts</strong><dd><code>Prevent multiple callbacks in eth_getTransactionByBlockNumberAndIndex</code></dd></summary>
<hr>

src/eth-handlers/eth_getTransactionByBlockNumberAndIndex.ts

<li>Added return statements to prevent multiple callbacks.<br> <li> Improved error handling with early returns.


</details>


  </td>
  <td><a href="https://github.com/shardeum/json-rpc-server/pull/141/files#diff-d486649d1e19c218c33a499f65659a66ae93d911ffe503968862977a5c723a01">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>eth_getTransactionByBlockHashAndIndex.test.ts</strong><dd><code>Update tests for single callback in </code><br><code>eth_getTransactionByBlockHashAndIndex</code></dd></summary>
<hr>

test/unit/eth-handlers/eth_getTransactionByBlockHashAndIndex.test.ts

<li>Updated tests to expect single callback execution.<br> <li> Removed assertions for multiple callback calls.


</details>


  </td>
  <td><a href="https://github.com/shardeum/json-rpc-server/pull/141/files#diff-b06f826e107122da544153ec56c99e9c68afeb8a0738f9638bb2845f6a1782fa">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>eth_getTransactionByBlockNumberAndIndex.test.ts</strong><dd><code>Update tests for single callback in </code><br><code>eth_getTransactionByBlockNumberAndIndex</code></dd></summary>
<hr>

test/unit/eth-handlers/eth_getTransactionByBlockNumberAndIndex.test.ts

<li>Updated tests to expect single callback execution.<br> <li> Removed assertions for multiple callback calls.


</details>


  </td>
  <td><a href="https://github.com/shardeum/json-rpc-server/pull/141/files#diff-c5ce618d43802c09c141e5eb4f2c738dcc777965c24cfd8e38edd7bbc34a0dd9">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>