### PR TITLE
SHARD-2291 - fix: add RATE_LIMIT env var

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -175,7 +175,7 @@ export const CONFIG: Config = {
   aalgWarmup: Boolean(process.env.AALG_WARMUP) || true,
   aalgWarmupServiceTPS: 10,
   recordTxStatus: false, // not safe for production, keep this off. Known issue.
-  rateLimit: true,
+  rateLimit: process.env.RATE_LIMIT ? process.env.RATE_LIMIT === 'true' : true, // if RATE_LIMIT is not set, default to true
   rateLimitOption: {
     softReject: true,
     limitFromAddress: true,


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Add support for `RATE_LIMIT` environment variable

- Default `rateLimit` to true if env var is unset

- Improve configurability for rate limiting feature


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.ts</strong><dd><code>Make rate limiting configurable via environment variable</code>&nbsp; </dd></summary>
<hr>

src/config.ts

<li>Replace hardcoded <code>rateLimit</code> with env-based configuration<br> <li> Use <code>process.env.RATE_LIMIT</code> to control rate limiting<br> <li> Default to <code>true</code> if environment variable is not set


</details>


  </td>
  <td><a href="https://github.com/shardeum/json-rpc-server/pull/155/files#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>