### PR TITLE
SHARD-2337 - fix: do not set static gas as it overrides not falls back

### DIFF
--- a/local_tests.patch
+++ b/local_tests.patch
@@ -10,8 +10,8 @@ index a633cf3..1c398bb 100644
 +  gasEstimateMethod: 'replayEngine', //serviceValidator or replayEngine or validator
    gasEstimateInvalidationIntervalInMs: 1000 * 60 * 60 * 2, // 2 hours
    gasEstimateUseCache: false,
--  staticGasEstimate: process.env.STATIC_GAS_ESTIMATE || '0x5B8D80', // comment out rather than delete this line
-+  staticGasEstimate: '0x2DC6C0', // comment out rather than delete this line
+-  staticGasEstimate: process.env.STATIC_GAS_ESTIMATE,
++  staticGasEstimate: '0x2DC6C0',
    defaultRequestTimeout: {
      default: 2000,
      contract: 7000,

--- a/src/config.ts
+++ b/src/config.ts
@@ -165,7 +165,7 @@ export const CONFIG: Config = {
   gasEstimateMethod: process.env.GAS_ESTIMATE_METHOD || 'serviceValidator', //serviceValidator or replayEngine or validator
   gasEstimateInvalidationIntervalInMs: 1000 * 60 * 60 * 2, // 2 hours
   gasEstimateUseCache: false,
-  staticGasEstimate: process.env.STATIC_GAS_ESTIMATE || '0x5B8D80', // comment out rather than delete this line
+  staticGasEstimate: process.env.STATIC_GAS_ESTIMATE,
   defaultRequestTimeout: {
     default: 2000,
     contract: 7000,


### PR DESCRIPTION
### **User description**
looks like we were commenting out this misconfigured gas estimate config when deploying.

fixes: https://linear.app/shm/issue/SHARD-2337/api-stagenetshardeumorg-returning-incorrect-gas-estimate-via-json-rpc


___

### **PR Type**
bug_fix


___

### **Description**
- Remove default value for `staticGasEstimate` in config

- Prevent static gas from overriding dynamic estimation

- Addresses incorrect gas estimate issue in API


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.ts</strong><dd><code>Remove default value for staticGasEstimate in config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config.ts

<li>Removed default value for <code>staticGasEstimate</code> in config<br> <li> Now uses only environment variable if set<br> <li> Prevents unintended override of gas estimation logic


</details>


  </td>
  <td><a href="https://github.com/shardeum/json-rpc-server/pull/158/files#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>