### PR TITLE
SHARD-2378 - Feat: add tx index in innerBlock

### DIFF
--- a/src/external/Collector.ts
+++ b/src/external/Collector.ts
@@ -350,7 +350,11 @@ class Collector extends BaseExternal {
         })
 
         if (txResponse.data.success && txResponse.data.transactions) {
-          resultBlock.transactions = txResponse.data.transactions.map((tx: any) => this.decodeTransaction(tx))
+          resultBlock.transactions = txResponse.data.transactions.map((tx: any, index: number) => {
+            const decodedTx = this.decodeTransaction(tx, index)
+            return decodedTx
+          })
+
           resultBlock.gasUsed = calculateBlockGasUsed(txResponse.data.transactions)
 
           // Extract transaction hash array
@@ -492,7 +496,7 @@ class Collector extends BaseExternal {
     return `${apiUrl}${queryParams.length > 0 ? `?${queryParams.join('&')}` : ''}`
   }
 
-  decodeTransaction(tx: any): readableTransaction {
+  decodeTransaction(tx: any, index?: number): readableTransaction {
     const readableReceipt = tx.wrappedEVMAccount.readableReceipt
     nestedCountersInstance.countEvent('collector', 'decodeTransaction')
     let result: any = null
@@ -503,7 +507,7 @@ class Collector extends BaseExternal {
     } catch (e) {
       // fallback to collectors readable receipt
       // v, r, s are not available in readableReceipt
-      return {
+      const txResult = {
         hash: readableReceipt.transactionHash,
         blockHash: readableReceipt.blockHash,
         blockNumber: readableReceipt.blockNumber,
@@ -516,11 +520,12 @@ class Collector extends BaseExternal {
         input: readableReceipt.input,
         gasPrice: readableReceipt.gasPrice,
         chainId: '0x' + CONFIG.chainId.toString(16),
-        transactionIndex: readableReceipt.transactionIndex,
+        transactionIndex: index !== undefined ? '0x' + index.toString(16) : readableReceipt.transactionIndex,
         v: '0x',
         r: '0x',
         s: '0x',
       } as readableLegacyTransaction
+      return txResult
     }
 
     if (CONFIG.verbose) console.log(txObj)
@@ -538,7 +543,7 @@ class Collector extends BaseExternal {
       input: '0x' + txObj.data.toString('hex'),
       gasPrice: readableReceipt.gasPrice,
       chainId: '0x' + CONFIG.chainId.toString(16),
-      transactionIndex: readableReceipt.transactionIndex,
+      transactionIndex: index !== undefined ? '0x' + index.toString(16) : readableReceipt.transactionIndex,
       v: '0x' + txObj.v?.toString('hex'),
       r: '0x' + txObj.r?.toString('hex'),
       s: '0x' + txObj.s?.toString('hex'),


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add transaction index (`transactionIndex`) to decoded transactions in `innerBlock`

- Update `decodeTransaction` to accept and use transaction index parameter

- Ensure transaction index is set in both fallback and normal decode paths

- Minor refactoring for transaction mapping logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Collector.ts</strong><dd><code>Add and propagate transaction index in transaction decoding</code></dd></summary>
<hr>

src/external/Collector.ts

<li>Pass transaction index to <code>decodeTransaction</code> when mapping transactions<br> <li> Update <code>decodeTransaction</code> to accept optional index parameter<br> <li> Set <code>transactionIndex</code> using index if provided, in both fallback and <br>normal decode paths<br> <li> Minor code refactoring for clarity and consistency


</details>


  </td>
  <td><a href="https://github.com/shardeum/json-rpc-server/pull/160/files#diff-bb6a7dc702c50cc9d1c83c07c43db4acb0ff9f618349931bad0b5534f93f4ae4">+10/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>