### PR TITLE
SHARD-2599 : enables local testing mode with high gas defaults

### DIFF
--- a/local-testing.config.example
+++ b/local-testing.config.example
@@ -1,0 +1,18 @@
+# Local Testing Configuration for JSON RPC Server
+# Copy these environment variables or export them for local development
+
+# Enable local testing mode with high gas defaults
+export LOCAL_TESTING_MODE=true
+export LOCAL_HIGH_GAS_DEFAULTS=true
+
+# Customize gas amount (optional, default shown)
+export LOCAL_CONSTANT_GAS=0xB71B00  # 12M gas for all transactions
+
+# Optional: Set a static gas estimate for all transactions (overrides local testing)
+# export STATIC_GAS_ESTIMATE=0xB71B00
+
+# Local development network configuration
+export RPC_PORT=8080
+export CHAIN_ID=8082
+export NODE_EXTERNAL_IP=127.0.0.1
+export NODE_EXTERNAL_PORT=9001

--- a/src/api.ts
+++ b/src/api.ts
@@ -1903,11 +1903,11 @@ export const methods = {
     logEventEmitter.emit('fn_start', ticket, api_name, performance.now())
     /* prettier-ignore */ if (firstLineLogs) { console.log('Running estimateGas', args) }
     // const result = '0x1C9C380' // 30 M gas
-    // if (config.staticGasEstimate) {
-    //   callback(null, config.staticGasEstimate)
-    //   countSuccessResponse(api_name, 'success using static gas estimate', 'static')
-    //   return
-    // }
+    if (config.staticGasEstimate) {
+      callback(null, config.staticGasEstimate)
+      countSuccessResponse(api_name, 'success using static gas estimate', 'static')
+      return
+    }
 
     // LOCAL TESTING MODE: High gas defaults for local development
     if (CONFIG.localTesting.enabled && CONFIG.localTesting.highGasDefaults) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1903,9 +1903,17 @@ export const methods = {
     logEventEmitter.emit('fn_start', ticket, api_name, performance.now())
     /* prettier-ignore */ if (firstLineLogs) { console.log('Running estimateGas', args) }
     // const result = '0x1C9C380' // 30 M gas
-    if (config.staticGasEstimate) {
-      callback(null, config.staticGasEstimate)
-      countSuccessResponse(api_name, 'success using static gas estimate', 'static')
+    // if (config.staticGasEstimate) {
+    //   callback(null, config.staticGasEstimate)
+    //   countSuccessResponse(api_name, 'success using static gas estimate', 'static')
+    //   return
+    // }
+
+    // LOCAL TESTING MODE: High gas defaults for local development
+    if (CONFIG.localTesting.enabled && CONFIG.localTesting.highGasDefaults) {
+      logEventEmitter.emit('fn_end', ticket, { success: true }, performance.now())
+      callback(null, CONFIG.localTesting.constantGas)
+      countSuccessResponse(api_name, 'success using local testing constant gas', 'local-testing')
       return
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,6 +124,11 @@ type Config = {
     filePath: string
     minFoundationNodesForInjectFilter: number
   }
+  localTesting: {
+    enabled: boolean
+    highGasDefaults: boolean
+    constantGas: string  // Default gas for all transactions
+  }
 }
 
 export type ServicePointTypes = 'aalg-warmup'
@@ -273,4 +278,28 @@ export const CONFIG: Config = {
     filePath: './foundation-nodes.json',
     minFoundationNodesForInjectFilter: 50,
   },
+  localTesting: {
+    enabled: Boolean(process.env.LOCAL_TESTING_MODE) || false,
+    highGasDefaults: Boolean(process.env.LOCAL_HIGH_GAS_DEFAULTS) || false,
+    constantGas: process.env.LOCAL_CONSTANT_GAS || '0xB71B00', // 12M gas for all transactions
+  },
 }
+
+// SAFETY CHECKS: Environment validation for local testing mode
+const isLocalNetwork = CONFIG.nodeIpInfo.externalIp === '127.0.0.1' ||
+                      CONFIG.nodeIpInfo.externalIp === 'localhost' 
+
+
+
+// Warn about potential misconfigurations
+if (CONFIG.localTesting.enabled && CONFIG.localTesting.highGasDefaults) {
+  if (!isLocalNetwork) {
+    console.warn('⚠️  WARNING: LOCAL_TESTING_MODE with high gas defaults enabled but network appears to be non-local!')
+    console.warn(`   Chain ID: ${CONFIG.chainId}, External IP: ${CONFIG.nodeIpInfo.externalIp}`)
+    console.warn('   This could result in expensive gas estimates on production networks.')
+  } else {
+    console.log('✅ Local testing mode enabled with high gas defaults for local development')
+    console.log(`   All transactions have the gas estimate as : ${CONFIG.localTesting.constantGas}`)
+  }
+}
+

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,7 +127,7 @@ type Config = {
   localTesting: {
     enabled: boolean
     highGasDefaults: boolean
-    constantGas: string  // Default gas for all transactions
+    constantGas: string // Default gas for all transactions
   }
 }
 
@@ -136,7 +136,7 @@ export type ServicePointTypes = 'aalg-warmup'
 export const CONFIG: Config = {
   websocket: {
     enabled: true,
-    serveSubscriptions: Boolean(process.env.WS_SAVE_SUBSCRIPTIONS) || false,
+    serveSubscriptions: Boolean(process.env.WS_SAVE_SUBSCRIPTIONS === 'true') || false,
     maxConnections: Number(process.env.WS_MAX_CONNECTIONS) || 1000,
     maxSubscriptionsPerSocket: Number(process.env.WS_MAX_SUBSCRIPTIONS_PER_SOCKET) || 50,
     connectionTimeoutMs: Number(process.env.WS_CONNECTION_TIMEOUT_MS) || 24 * 60 * 60 * 1000, // 1 day in ms
@@ -163,7 +163,7 @@ export const CONFIG: Config = {
   askLocalHostForArchiver: true,
   rotationInterval: 60,
   faucetServerUrl: process.env.FAUCET_URL || 'https://faucet.liberty10.shardeum.org',
-  queryFromValidator: Boolean(process.env.QUERY_FROM_VALIDATOR) || true,
+  queryFromValidator: Boolean(process.env.QUERY_FROM_VALIDATOR === 'true') || true,
   explorerUrl: process.env.EXPLORER_URL || 'http://127.0.0.1:6001',
   queryFromExplorer: false,
   generateTxTimestamp: true,
@@ -179,7 +179,7 @@ export const CONFIG: Config = {
     account: 10000,
     full_nodelist: 10000,
   },
-  aalgWarmup: Boolean(process.env.AALG_WARMUP) || true,
+  aalgWarmup: Boolean(process.env.AALG_WARMUP === 'true') || true,
   aalgWarmupServiceTPS: 10,
   recordTxStatus: false, // not safe for production, keep this off. Known issue.
   rateLimit: process.env.RATE_LIMIT ? process.env.RATE_LIMIT === 'true' : true, // if RATE_LIMIT is not set, default to true
@@ -199,7 +199,7 @@ export const CONFIG: Config = {
   adaptiveRejection: true,
   filterDeadNodesFromArchiver: false,
   verbose: false,
-  enableRequestLogger: process.env.SHARDEUM_JSONRPC_ENABLE_REQUEST_LOGGING === 'true' || false,
+  enableRequestLogger: Boolean(process.env.SHARDEUM_JSONRPC_ENABLE_REQUEST_LOGGING === 'true') || false,
   verboseRequestWithRetry: false,
   verboseAALG: false,
   firstLineLogs: true, // default is true and turn off for prod for perf
@@ -279,17 +279,14 @@ export const CONFIG: Config = {
     minFoundationNodesForInjectFilter: 50,
   },
   localTesting: {
-    enabled: Boolean(process.env.LOCAL_TESTING_MODE) || false,
-    highGasDefaults: Boolean(process.env.LOCAL_HIGH_GAS_DEFAULTS) || false,
+    enabled: Boolean(process.env.LOCAL_TESTING_MODE === 'true') || false,
+    highGasDefaults: Boolean(process.env.LOCAL_HIGH_GAS_DEFAULTS === 'true') || false,
     constantGas: process.env.LOCAL_CONSTANT_GAS || '0xB71B00', // 12M gas for all transactions
   },
 }
 
 // SAFETY CHECKS: Environment validation for local testing mode
-const isLocalNetwork = CONFIG.nodeIpInfo.externalIp === '127.0.0.1' ||
-                      CONFIG.nodeIpInfo.externalIp === 'localhost' 
-
-
+const isLocalNetwork = CONFIG.nodeIpInfo.externalIp === '127.0.0.1' || CONFIG.nodeIpInfo.externalIp === 'localhost'
 
 // Warn about potential misconfigurations
 if (CONFIG.localTesting.enabled && CONFIG.localTesting.highGasDefaults) {
@@ -302,4 +299,3 @@ if (CONFIG.localTesting.enabled && CONFIG.localTesting.highGasDefaults) {
     console.log(`   All transactions have the gas estimate as : ${CONFIG.localTesting.constantGas}`)
   }
 }
-


### PR DESCRIPTION
### **User description**
Adds a local testing mode that configures high gas defaults for local development environments.

This allows for faster development cycles by avoiding gas estimation on local networks, and instead using a constant gas amount. A warning is logged if local testing mode is enabled on a non-local network, to prevent accidental use in production environments.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduces local testing mode with high gas defaults

- Adds environment-based configuration for local testing

- Implements safety checks and warnings for misconfiguration

- Provides example config file for local testing setup


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.ts</strong><dd><code>Enable local testing mode for gas estimation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/api.ts

<li>Implements local testing mode for gas estimation<br> <li> Uses constant gas value when local testing is enabled<br> <li> Emits log events and counts responses for local testing<br> <li> Comments out previous static gas estimate logic


</details>


  </td>
  <td><a href="https://github.com/shardeum/json-rpc-server/pull/171/files#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.ts</strong><dd><code>Add localTesting config and environment validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config.ts

<li>Adds <code>localTesting</code> config section with env-based toggles<br> <li> Sets default constant gas value for local testing<br> <li> Implements safety checks for local testing on non-local networks<br> <li> Logs warnings or confirmations based on environment


</details>


  </td>
  <td><a href="https://github.com/shardeum/json-rpc-server/pull/171/files#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>local-testing.config.example</strong><dd><code>Provide example config for local testing mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

local-testing.config.example

<li>Adds example environment variable config for local testing<br> <li> Documents enabling local testing and customizing gas defaults<br> <li> Includes local network and port settings for development


</details>


  </td>
  <td><a href="https://github.com/shardeum/json-rpc-server/pull/171/files#diff-24f840960f4bec4c72bcd68ba4997ca8a2417471d7a137a189cf21dd61eb1a1f">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>